### PR TITLE
Add filter tooltip to partitioned storage cells

### DIFF
--- a/src/main/java/com/glodblock/github/common/item/ItemBasicFluidStorageCell.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemBasicFluidStorageCell.java
@@ -30,6 +30,7 @@ import com.google.common.base.Optional;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
@@ -140,6 +141,14 @@ public class ItemBasicFluidStorageCell extends AEBaseItem implements IStorageFlu
                 {
                     final String list = (handler.getIncludeExcludeMode() == IncludeExclude.WHITELIST ? GuiText.Included : GuiText.Excluded).getLocal();
                     lines.add(GuiText.Partitioned.getLocal() + " - " + list + ' ' + GuiText.Precise.getLocal());
+
+                    if (GuiScreen.isShiftKeyDown())
+                    {
+                        lines.add(GuiText.Filter.getLocal() + ": ");
+                        for (IAEFluidStack aeFluidStack : handler.getPartitionInv()) {
+                            if (aeFluidStack != null) lines.add("  " + aeFluidStack.getFluidStack().getLocalizedName());
+                        }
+                    }
                 }
             }
         }

--- a/src/main/java/com/glodblock/github/common/storage/FluidCellInventoryHandler.java
+++ b/src/main/java/com/glodblock/github/common/storage/FluidCellInventoryHandler.java
@@ -55,6 +55,11 @@ public class FluidCellInventoryHandler extends MEInventoryHandler<IAEFluidStack>
     }
 
     @Override
+    public Iterable<IAEFluidStack> getPartitionInv() {
+        return (Iterable<IAEFluidStack>) Ae2Reflect.getPartitionList(this).getItems();
+    }
+
+    @Override
     public boolean isPreformatted()
     {
         return !Ae2Reflect.getPartitionList(this).isEmpty();

--- a/src/main/java/com/glodblock/github/common/storage/IFluidCellInventoryHandler.java
+++ b/src/main/java/com/glodblock/github/common/storage/IFluidCellInventoryHandler.java
@@ -1,10 +1,13 @@
 package com.glodblock.github.common.storage;
 
 import appeng.api.config.IncludeExclude;
+import appeng.api.storage.data.IAEFluidStack;
 
 public interface IFluidCellInventoryHandler {
 
     IFluidCellInventory getCellInv();
+
+    Iterable<IAEFluidStack> getPartitionInv();
 
     boolean isPreformatted();
 


### PR DESCRIPTION
Just like regular AE2 storage cells have, a filter tooltip on partitioned fluid storage cells. Instead of checking fluids in the cell workbench, now you can just hold shift key while hovering over the cell.
![image](https://user-images.githubusercontent.com/22837945/194799374-002b613c-7f77-4a5f-993d-6b3797d8e3e5.png)
