### PR TITLE
make blocking mode work with fluid p2ps

### DIFF
--- a/src/main/java/com/glodblock/github/inventory/FluidConvertingInventoryAdaptor.java
+++ b/src/main/java/com/glodblock/github/inventory/FluidConvertingInventoryAdaptor.java
@@ -201,18 +201,9 @@ public class FluidConvertingInventoryAdaptor extends InventoryAdaptor {
                             p2p = invFluidsP2P.getInput();
                             checkedInput = true;
                         }
-
                         if (p2p == invFluidsP2P || p2p == null)
                             continue;
-
-                        try {
-                            Method getTarget = p2p.getClass().getDeclaredMethod("getTarget");
-                            getTarget.setAccessible(true);
-                            tankInfos.add(((IFluidHandler) getTarget.invoke(p2p)).getTankInfo(p2p.getSide().getOpposite()));
-                        } catch (NoSuchMethodException  | InvocationTargetException | IllegalAccessException e) {
-                            // skip if we can't read the target
-                        }
-
+                        tankInfos.add(Ae2Reflect.getP2PLiquidTarget(p2p).getTankInfo(p2p.getSide().getOpposite()));
                     }
                 } catch (GridAccessException e) {
                     // ignore

--- a/src/main/java/com/glodblock/github/inventory/FluidConvertingInventoryAdaptor.java
+++ b/src/main/java/com/glodblock/github/inventory/FluidConvertingInventoryAdaptor.java
@@ -2,6 +2,8 @@ package com.glodblock.github.inventory;
 
 import appeng.api.config.FuzzyMode;
 import appeng.api.config.InsertionMode;
+import appeng.me.GridAccessException;
+import appeng.parts.p2p.PartP2PLiquids;
 import appeng.tile.misc.TileInterface;
 import appeng.tile.networking.TileCableBus;
 import appeng.util.InventoryAdaptor;
@@ -27,8 +29,12 @@ import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidHandler;
 
 import javax.annotation.Nullable;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
+import java.util.LinkedList;
 
 public class FluidConvertingInventoryAdaptor extends InventoryAdaptor {
 
@@ -179,11 +185,47 @@ public class FluidConvertingInventoryAdaptor extends InventoryAdaptor {
 
     @Override
     public boolean containsItems() {
-        if (invFluids != null && invFluids.getTankInfo(side) != null) {
-            for (FluidTankInfo tank : invFluids.getTankInfo(side)) {
-                FluidStack fluid = tank.fluid;
-                if (fluid != null && fluid.amount > 0) {
-                    return true;
+        if (invFluids != null && invFluids.getTankInfo(this.side) != null) {
+            List<FluidTankInfo[]> tankInfos = new LinkedList<>();
+            if (invFluids instanceof TileCableBus && ((TileCableBus) invFluids).getPart(this.side) instanceof PartP2PLiquids) {
+                // read other ends of p2p for blocking mode
+                PartP2PLiquids invFluidsP2P = (PartP2PLiquids) ((TileCableBus) invFluids).getPart(this.side);
+                try {
+                    Iterator<PartP2PLiquids> it = invFluidsP2P.getOutputs().iterator();
+                    boolean checkedInput = false;
+                    while (it.hasNext() || !checkedInput) {
+                        PartP2PLiquids p2p;
+                        if (it.hasNext()) {
+                            p2p = it.next();
+                        } else {
+                            p2p = invFluidsP2P.getInput();
+                            checkedInput = true;
+                        }
+
+                        if (p2p == invFluidsP2P || p2p == null)
+                            continue;
+
+                        try {
+                            Method getTarget = p2p.getClass().getDeclaredMethod("getTarget");
+                            getTarget.setAccessible(true);
+                            tankInfos.add(((IFluidHandler) getTarget.invoke(p2p)).getTankInfo(p2p.getSide().getOpposite()));
+                        } catch (NoSuchMethodException  | InvocationTargetException | IllegalAccessException e) {
+                            // skip if we can't read the target
+                        }
+
+                    }
+                } catch (GridAccessException e) {
+                    // ignore
+                }
+            } else {
+                tankInfos.add(invFluids.getTankInfo(this.side));
+            }
+            for (FluidTankInfo[] tankInfoArray : tankInfos) {
+                for (FluidTankInfo tank : tankInfoArray) {
+                    FluidStack fluid = tank.fluid;
+                    if (fluid != null && fluid.amount > 0) {
+                        return true;
+                    }
                 }
             }
         }

--- a/src/main/java/com/glodblock/github/util/Ae2Reflect.java
+++ b/src/main/java/com/glodblock/github/util/Ae2Reflect.java
@@ -13,8 +13,10 @@ import appeng.crafting.MECraftingInventory;
 import appeng.me.cluster.implementations.CraftingCPUCluster;
 import appeng.me.storage.MEInventoryHandler;
 import appeng.me.storage.MEPassThrough;
+import appeng.parts.p2p.PartP2PLiquids;
 import appeng.util.inv.ItemSlot;
 import appeng.util.prioitylist.IPartitionList;
+import net.minecraftforge.fluids.IFluidHandler;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -36,6 +38,7 @@ public class Ae2Reflect {
     private static final Method mCPU_getGrid;
     private static final Method mCPU_postChange;
     private static final Method mCPU_markDirty;
+    private static final Method mP2PLiquids_getTarget;
 
     static {
         try {
@@ -53,6 +56,7 @@ public class Ae2Reflect {
             mCPU_getGrid = reflectMethod(CraftingCPUCluster.class, "getGrid");
             mCPU_postChange = reflectMethod(CraftingCPUCluster.class, "postChange", IAEItemStack.class, BaseActionSource.class);
             mCPU_markDirty = reflectMethod(CraftingCPUCluster.class, "markDirty");
+            mP2PLiquids_getTarget = reflectMethod(PartP2PLiquids.class, "getTarget");
         } catch (Exception e) {
             throw new IllegalStateException("Failed to initialize AE2 reflection hacks!", e);
         }
@@ -169,6 +173,14 @@ public class Ae2Reflect {
             mCPU_markDirty.invoke(cpu);
         } catch (Exception e) {
             throw new IllegalStateException("Failed to invoke method: " + mCPU_markDirty, e);
+        }
+    }
+
+    public static IFluidHandler getP2PLiquidTarget(PartP2PLiquids p2p) {
+        try {
+            return (IFluidHandler) mP2PLiquids_getTarget.invoke(p2p);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to invoke method: " + mP2PLiquids_getTarget, e);
         }
     }
 


### PR DESCRIPTION
p2ps always report empty with `getTankInfo` so this code queries the other ends to see if they're empty or not

it may be a good idea to also patch ae2 to make `getTarget` public so this code won't need reflection