### PR TITLE
fluid packet decode add support to use conduit to export fluid

### DIFF
--- a/src/main/java/com/glodblock/github/common/tile/TileFluidPacketDecoder.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileFluidPacketDecoder.java
@@ -182,6 +182,7 @@ public class TileFluidPacketDecoder extends AENetworkTile
         ItemStack fluidPacket = this.inventory.getStackInSlot(0);
         if (fluidPacket != null) {
             FluidStack fs = ItemFluidPacket.getFluidStack(fluidPacket);
+            if (fs == null) return null;
             if (fs.isFluidEqual(requestFluid)) {
                 if (fs.amount > requestFluid.amount) {
                     fs.amount -= requestFluid.amount;
@@ -201,6 +202,7 @@ public class TileFluidPacketDecoder extends AENetworkTile
         ItemStack fluidPacket = this.inventory.getStackInSlot(0);
         if (fluidPacket != null) {
             FluidStack requestFluid = ItemFluidPacket.getFluidStack(fluidPacket);
+            if (requestFluid == null) return null;
             requestFluid.amount = maxDrain;
             return this.drain(requestFluid, doDrain);
         }
@@ -224,6 +226,7 @@ public class TileFluidPacketDecoder extends AENetworkTile
             return new FluidTankInfo[0];
         } else {
             FluidStack fs = ItemFluidPacket.getFluidStack(fluidPacket);
+            if (fs == null) return new FluidTankInfo[0];
             return new FluidTankInfo[] { new FluidTankInfo(fs, fs.amount) };
         }
     }

--- a/src/main/java/com/glodblock/github/common/tile/TileFluidPacketDecoder.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileFluidPacketDecoder.java
@@ -4,7 +4,8 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraftforge.fluids.*;
 
 import appeng.api.networking.GridFlags;
 import appeng.api.networking.IGridNode;
@@ -30,7 +31,8 @@ import appeng.util.item.AEFluidStack;
 
 import com.glodblock.github.common.item.ItemFluidPacket;
 
-public class TileFluidPacketDecoder extends AENetworkTile implements IGridTickable, IAEAppEngInventory, IInventory {
+public class TileFluidPacketDecoder extends AENetworkTile
+        implements IGridTickable, IAEAppEngInventory, IInventory, IFluidHandler {
 
     private final AppEngInternalInventory inventory = new AppEngInternalInventory(this, 1);
     private final BaseActionSource ownActionSource = new MachineSource(this);
@@ -163,5 +165,66 @@ public class TileFluidPacketDecoder extends AENetworkTile implements IGridTickab
     @Override
     public boolean isItemValidForSlot(int slot, ItemStack stack) {
         return stack.getItem() instanceof ItemFluidPacket;
+    }
+
+    @Override
+    public int fill(ForgeDirection from, FluidStack resource, boolean doFill) {
+        return 0;
+    }
+
+    @Override
+    public FluidStack drain(ForgeDirection from, FluidStack requestFluid, boolean doDrain) {
+        return this.drain(requestFluid, doDrain);
+    }
+
+    private FluidStack drain(FluidStack requestFluid, boolean doDrain) {
+        if (requestFluid == null || requestFluid.amount <= 0) return null;
+        ItemStack fluidPacket = this.inventory.getStackInSlot(0);
+        if (fluidPacket != null) {
+            FluidStack fs = ItemFluidPacket.getFluidStack(fluidPacket);
+            if (fs.isFluidEqual(requestFluid)) {
+                if (fs.amount > requestFluid.amount) {
+                    fs.amount -= requestFluid.amount;
+                    if (doDrain) this.inventory.setInventorySlotContents(0, ItemFluidPacket.newStack(fs));
+                    return requestFluid;
+                } else {
+                    if (doDrain) this.inventory.setInventorySlotContents(0, null);
+                    return fs;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public FluidStack drain(ForgeDirection from, int maxDrain, boolean doDrain) {
+        ItemStack fluidPacket = this.inventory.getStackInSlot(0);
+        if (fluidPacket != null) {
+            FluidStack requestFluid = ItemFluidPacket.getFluidStack(fluidPacket);
+            requestFluid.amount = maxDrain;
+            return this.drain(requestFluid, doDrain);
+        }
+        return null;
+    }
+
+    @Override
+    public boolean canFill(ForgeDirection from, Fluid fluid) {
+        return false;
+    }
+
+    @Override
+    public boolean canDrain(ForgeDirection from, Fluid fluid) {
+        return true;
+    }
+
+    @Override
+    public FluidTankInfo[] getTankInfo(ForgeDirection from) {
+        ItemStack fluidPacket = this.inventory.getStackInSlot(0);
+        if (fluidPacket == null) {
+            return new FluidTankInfo[0];
+        } else {
+            FluidStack fs = ItemFluidPacket.getFluidStack(fluidPacket);
+            return new FluidTankInfo[] { new FluidTankInfo(fs, fs.amount) };
+        }
     }
 }

--- a/src/main/java/com/glodblock/github/crossmod/waila/Tooltip.java
+++ b/src/main/java/com/glodblock/github/crossmod/waila/Tooltip.java
@@ -15,6 +15,14 @@ public class Tooltip {
         return String.format("%s: %s mB", name, NumberFormat.getInstance().format(amount));
     }
 
+    public static String fluidFormat(String name, long amount, long capacity) {
+        return String.format(
+                "%s: %s mB / %s mB",
+                name,
+                NumberFormat.getInstance().format(amount),
+                NumberFormat.getInstance().format(capacity));
+    }
+
     public static String partFluidBusFormat(int amount) {
         return String
                 .format("%s: %s mB/t", I18n.format(NameConst.WAILA_SPEED), NumberFormat.getInstance().format(amount));

--- a/src/main/java/com/glodblock/github/crossmod/waila/VanillaTileWailaDataProvider.java
+++ b/src/main/java/com/glodblock/github/crossmod/waila/VanillaTileWailaDataProvider.java
@@ -1,0 +1,71 @@
+package com.glodblock.github.crossmod.waila;
+
+import java.util.List;
+
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
+import mcp.mobius.waila.api.IWailaDataProvider;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+
+import com.glodblock.github.crossmod.waila.vanilla.FluidInvWailaDataProvider;
+import com.google.common.collect.Lists;
+
+public class VanillaTileWailaDataProvider implements IWailaDataProvider {
+
+    private final List<IWailaDataProvider> providers;
+
+    public VanillaTileWailaDataProvider() {
+        final IWailaDataProvider fluidInv = new FluidInvWailaDataProvider();
+        this.providers = Lists.newArrayList(fluidInv);
+    }
+
+    @Override
+    public ItemStack getWailaStack(final IWailaDataAccessor accessor, final IWailaConfigHandler config) {
+        return null;
+    }
+
+    @Override
+    public List<String> getWailaHead(final ItemStack itemStack, final List<String> currentToolTip,
+            final IWailaDataAccessor accessor, final IWailaConfigHandler config) {
+        for (final IWailaDataProvider provider : this.providers) {
+            provider.getWailaHead(itemStack, currentToolTip, accessor, config);
+        }
+
+        return currentToolTip;
+    }
+
+    @Override
+    public List<String> getWailaBody(final ItemStack itemStack, final List<String> currentToolTip,
+            final IWailaDataAccessor accessor, final IWailaConfigHandler config) {
+        for (final IWailaDataProvider provider : this.providers) {
+            provider.getWailaBody(itemStack, currentToolTip, accessor, config);
+        }
+
+        return currentToolTip;
+    }
+
+    @Override
+    public List<String> getWailaTail(final ItemStack itemStack, final List<String> currentToolTip,
+            final IWailaDataAccessor accessor, final IWailaConfigHandler config) {
+        for (final IWailaDataProvider provider : this.providers) {
+            provider.getWailaTail(itemStack, currentToolTip, accessor, config);
+        }
+
+        return currentToolTip;
+    }
+
+    @Override
+    public NBTTagCompound getNBTData(final EntityPlayerMP player, final TileEntity te, final NBTTagCompound tag,
+            final World world, final int x, final int y, final int z) {
+        for (final IWailaDataProvider provider : this.providers) {
+            provider.getNBTData(player, te, tag, world, x, y, z);
+        }
+
+        return tag;
+    }
+}

--- a/src/main/java/com/glodblock/github/crossmod/waila/WailaInit.java
+++ b/src/main/java/com/glodblock/github/crossmod/waila/WailaInit.java
@@ -2,6 +2,9 @@ package com.glodblock.github.crossmod.waila;
 
 import mcp.mobius.waila.api.IWailaDataProvider;
 import mcp.mobius.waila.api.IWailaRegistrar;
+
+import net.minecraft.tileentity.TileEntity;
+
 import appeng.api.parts.IPartHost;
 import appeng.tile.AEBaseTile;
 import appeng.util.Platform;
@@ -23,5 +26,10 @@ public class WailaInit {
         final IWailaDataProvider tile = new TileWailaDataProvider();
         registrar.registerBodyProvider(tile, AEBaseTile.class);
         registrar.registerNBTProvider(tile, AEBaseTile.class);
+
+        final IWailaDataProvider vanillaTile = new VanillaTileWailaDataProvider();
+        registrar.registerBodyProvider(vanillaTile, TileEntity.class);
+        registrar.registerNBTProvider(vanillaTile, TileEntity.class);
+
     }
 }

--- a/src/main/java/com/glodblock/github/crossmod/waila/vanilla/FluidInvWailaDataProvider.java
+++ b/src/main/java/com/glodblock/github/crossmod/waila/vanilla/FluidInvWailaDataProvider.java
@@ -1,0 +1,51 @@
+package com.glodblock.github.crossmod.waila.vanilla;
+
+import java.util.List;
+
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+import net.minecraftforge.fluids.FluidTankInfo;
+
+import appeng.integration.modules.waila.BaseWailaDataProvider;
+
+import com.glodblock.github.common.tile.TileCertusQuartzTank;
+import com.glodblock.github.crossmod.waila.Tooltip;
+import com.glodblock.github.util.Util;
+
+public class FluidInvWailaDataProvider extends BaseWailaDataProvider {
+
+    @Override
+    public List<String> getWailaBody(final ItemStack itemStack, final List<String> currentToolTip,
+            final IWailaDataAccessor accessor, final IWailaConfigHandler config) {
+        final TileEntity te = accessor.getTileEntity();
+        if (te instanceof TileCertusQuartzTank) {
+            if (accessor.getNBTData().hasKey("fluidInv")) {
+                NBTTagCompound data = (NBTTagCompound) accessor.getNBTData().getTag("fluidInv");
+                for (FluidTankInfo info : Util.FluidUtil.fluidTankInfoReadFromNBT(data)) {
+                    if (info.fluid == null) continue;
+                    currentToolTip
+                            .add(Tooltip.fluidFormat(info.fluid.getLocalizedName(), info.fluid.amount, info.capacity));
+                }
+            }
+        }
+        return currentToolTip;
+    }
+
+    @Override
+    public NBTTagCompound getNBTData(final EntityPlayerMP player, final TileEntity te, final NBTTagCompound tag,
+            final World world, final int x, final int y, final int z) {
+        if (te instanceof TileCertusQuartzTank) {
+            NBTTagCompound data = new NBTTagCompound();
+            Util.FluidUtil.fluidTankInfoWriteToNBT(((TileCertusQuartzTank) te).getInternalFluid(), data);
+            tag.setTag("fluidInv", data);
+            te.writeToNBT(tag);
+        }
+        return tag;
+    }
+}

--- a/src/main/java/com/glodblock/github/util/BlockPos.java
+++ b/src/main/java/com/glodblock/github/util/BlockPos.java
@@ -40,6 +40,10 @@ public class BlockPos {
         return new BlockPos(this.x + face.offsetX, this.y + face.offsetY, this.z + face.offsetZ, this.w);
     }
 
+    public BlockPos getOffSet(int x, int y, int z) {
+        return new BlockPos(this.x + x, this.y + y, this.z + z, this.w);
+    }
+
     public TileEntity getTileEntity() {
         if (w != null) {
             return w.getTileEntity(x, y, z);

--- a/src/main/java/com/glodblock/github/util/Util.java
+++ b/src/main/java/com/glodblock/github/util/Util.java
@@ -3,6 +3,8 @@ package com.glodblock.github.util;
 import static com.glodblock.github.common.item.ItemBaseWirelessTerminal.infinityBoosterCard;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import net.minecraft.entity.player.EntityPlayer;
@@ -414,6 +416,36 @@ public final class Util {
     }
 
     public static class FluidUtil {
+
+        public static void fluidTankInfoWriteToNBT(FluidTankInfo[] infos, NBTTagCompound data) {
+            int i = 0;
+            for (FluidTankInfo info : infos) {
+                if (info.fluid != null && info.fluid.amount > 0) {
+                    NBTTagCompound fs = new NBTTagCompound();
+                    info.fluid.writeToNBT(fs);
+                    fs.setInteger("capacity", info.capacity);
+                    data.setTag("#" + i, fs);
+                }
+                i++;
+            }
+            data.setInteger("fluidInvSize", i);
+        }
+
+        public static FluidTankInfo[] fluidTankInfoReadFromNBT(NBTTagCompound data) {
+            int i = 0;
+            List<FluidTankInfo> infos = new ArrayList<>();
+            while (data.hasKey("fluidInvSize") && i < data.getInteger("fluidInvSize")) {
+                if (data.hasKey("#" + i)) {
+                    NBTTagCompound tag = (NBTTagCompound) data.getTag("#" + i);
+                    FluidStack fs = FluidStack.loadFluidStackFromNBT(tag);
+                    infos.add(new FluidTankInfo(fs, tag.getInteger("capacity")));
+                } else {
+                    infos.add(new FluidTankInfo(null, 0));
+                }
+                i++;
+            }
+            return infos.toArray(new FluidTankInfo[0]);
+        }
 
         public static IAEFluidStack createAEFluidStack(Fluid fluid) {
             return createAEFluidStack(new FluidStack(fluid, FluidContainerRegistry.BUCKET_VOLUME));


### PR DESCRIPTION
fluid packet decoder add support to use conduit to export fluid
![52](https://user-images.githubusercontent.com/33802162/221539524-2b379b18-41d0-44f5-aff9-002f024abdfa.gif)

Certus Quartz Tank add waila support

The fluid in the storage tank now automatically flows downwards
![51](https://user-images.githubusercontent.com/33802162/221516029-be499f09-6e5d-46d1-9e6b-1c1c81c5da6c.gif)
