### PR TITLE
fix fluid export bus voiding liquids on a subnet connected with "extract only" bus

### DIFF
--- a/src/main/java/com/glodblock/github/common/parts/PartFluidExportBus.java
+++ b/src/main/java/com/glodblock/github/common/parts/PartFluidExportBus.java
@@ -136,7 +136,9 @@ public class PartFluidExportBus extends FCSharedFluidBus implements ICraftingReq
                                     cg,
                                     this.source);
                         }
-
+                        // can fill stack size
+                        toExtract.setStackSize(fh.fill(this.getSide().getOpposite(), toExtract.getFluidStack(), false));
+                        if (toExtract.getStackSize() <= 0) continue;
                         final IAEFluidStack real = inv.extractItems(toExtract, Actionable.MODULATE, this.source);
 
                         if (real != null && isAllowed) {


### PR DESCRIPTION
fix fluid export bus voiding liquids on a subnet connected with "extract only" bus
close https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12763