### PR TITLE
Network throttle: Force ME update packets to be sent once every 50ms.

### DIFF
--- a/src/main/java/com/glodblock/github/FluidCraft.java
+++ b/src/main/java/com/glodblock/github/FluidCraft.java
@@ -14,6 +14,7 @@ import com.glodblock.github.loader.ChannelLoader;
 import com.glodblock.github.loader.ItemAndBlockHolder;
 import com.glodblock.github.loader.RecipeLoader;
 import com.glodblock.github.loader.filter.FluidFilter;
+import com.glodblock.github.network.SPacketMEUpdateBuffer;
 import com.glodblock.github.proxy.CommonProxy;
 import com.glodblock.github.util.ModAndClassUtil;
 
@@ -80,6 +81,16 @@ public class FluidCraft {
         }
 
         proxy.postInit(event);
+    }
+
+    @Mod.EventHandler
+    public void onServerStart(FMLServerStartingEvent event) {
+        SPacketMEUpdateBuffer.init();
+    }
+
+    @Mod.EventHandler
+    public void onServerStop(FMLServerStoppedEvent event) {
+        SPacketMEUpdateBuffer.disable();
     }
 
     @Mod.EventHandler

--- a/src/main/java/com/glodblock/github/client/gui/container/base/FCContainerMonitor.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/base/FCContainerMonitor.java
@@ -30,6 +30,7 @@ import appeng.util.IConfigManagerHost;
 import appeng.util.Platform;
 
 import com.glodblock.github.inventory.item.IWirelessTerminal;
+import com.glodblock.github.network.SPacketMEUpdateBuffer;
 
 public abstract class FCContainerMonitor<T extends IAEStack<T>> extends FCBaseContainer
         implements IConfigManagerHost, IConfigurableObject, IMEMonitorHandlerReceiver<T> {
@@ -158,6 +159,10 @@ public abstract class FCContainerMonitor<T extends IAEStack<T>> extends FCBaseCo
         super.onContainerClosed(player);
         if (this.monitor != null) {
             this.monitor.removeListener(this);
+            if (player instanceof EntityPlayerMP && Platform.isServer()) {
+                SPacketMEUpdateBuffer.clear((EntityPlayerMP) player);
+            }
+
         }
     }
 

--- a/src/main/java/com/glodblock/github/common/Config.java
+++ b/src/main/java/com/glodblock/github/common/Config.java
@@ -18,6 +18,7 @@ public class Config {
     public static boolean blacklistEssentiaGas;
     public static double portableCellBattery;
     public static int packetSize;
+    public static int packetRate;
 
     public static void run() {
         loadCategory();
@@ -55,6 +56,10 @@ public class Config {
         packetSize = Config.get("Fluid Craft for AE2", "packetSize", 256, "Number of items to be sent per packet")
                 .getInt();
         if (packetSize <= 0) packetSize = 256;
+        packetRate = Config
+                .get("Fluid Craft for AE2", "packetRate", 50, "Period at which packets are dispatched, in ms.")
+                .getInt();
+        if (packetRate <= 0) packetRate = 50;
         if (Config.hasChanged()) Config.save();
     }
 

--- a/src/main/java/com/glodblock/github/network/CPacketLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/network/CPacketLevelMaintainer.java
@@ -1,5 +1,8 @@
 package com.glodblock.github.network;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.annotation.Nullable;
 
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -9,7 +12,6 @@ import net.minecraft.nbt.NBTTagCompound;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.util.item.AEItemStack;
 
-import com.glodblock.github.FluidCraft;
 import com.glodblock.github.client.gui.container.ContainerLevelMaintainer;
 import com.glodblock.github.common.tile.TileLevelMaintainer;
 
@@ -88,7 +90,7 @@ public class CPacketLevelMaintainer implements IMessage {
     public static class Handler implements IMessageHandler<CPacketLevelMaintainer, IMessage> {
 
         private void refresh(ContainerLevelMaintainer cca, EntityPlayerMP player) {
-            SPacketMEItemInvUpdate packet = new SPacketMEItemInvUpdate();
+            List<IAEItemStack> toSend = new ArrayList<>(TileLevelMaintainer.REQ_COUNT);
             for (int i = 0; i < TileLevelMaintainer.REQ_COUNT; i++) {
                 IAEItemStack is = cca.getTile().requests.getRequestQtyStack(i);
                 IAEItemStack is1 = cca.getTile().requests.getRequestBatches().getStack(i);
@@ -96,7 +98,7 @@ public class CPacketLevelMaintainer implements IMessage {
                     if (is1 != null) {
                         NBTTagCompound data;
                         data = is1.getItemStack().getTagCompound();
-                        packet.appendItem(
+                        toSend.add(
                                 setTag(
                                         is,
                                         is1.getStackSize(),
@@ -104,11 +106,11 @@ public class CPacketLevelMaintainer implements IMessage {
                                         data.getBoolean("Enable"),
                                         cca.getTile().requests.getState(i).ordinal()));
                     } else {
-                        packet.appendItem(setTag(is, 0, i, true, 0));
+                        toSend.add(setTag(is, 0, i, true, 0));
                     }
                 }
             }
-            FluidCraft.proxy.netHandler.sendTo(packet, player);
+            SPacketMEUpdateBuffer.scheduleItemUpdate(player, toSend);
         }
 
         @Nullable

--- a/src/main/java/com/glodblock/github/network/SPacketMEFluidInvUpdate.java
+++ b/src/main/java/com/glodblock/github/network/SPacketMEFluidInvUpdate.java
@@ -1,7 +1,6 @@
 package com.glodblock.github.network;
 
 import java.io.IOException;
-import java.nio.BufferOverflowException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -13,7 +12,6 @@ import appeng.util.item.AEFluidStack;
 
 import com.glodblock.github.client.gui.GuiFluidCraftConfirm;
 import com.glodblock.github.client.gui.GuiFluidMonitor;
-import com.glodblock.github.common.Config;
 
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
@@ -40,8 +38,12 @@ public class SPacketMEFluidInvUpdate implements IMessage {
 
     /**
      * If resort, call "updateView()". Used when multiple packets are sent to open an inventory; only the last packet
-     * should resort.
+     * should resort. <<<<<<< HEAD
      *
+     * =======
+     *
+     * >>>>>>> 669eb96... Network throttle: Force ME update packets to be sent once every 50ms.
+     * 
      * @param resort whether this packet should resort the term or not
      */
     public SPacketMEFluidInvUpdate(boolean resort) {
@@ -82,12 +84,8 @@ public class SPacketMEFluidInvUpdate implements IMessage {
         this.resort = resort;
     }
 
-    public void appendFluid(final IAEFluidStack is) throws BufferOverflowException {
-        if (list.size() <= Config.packetSize) {
-            list.add(is);
-        } else {
-            throw new BufferOverflowException();
-        }
+    public void appendFluid(final IAEFluidStack is) {
+        list.add(is);
     }
 
     public boolean isEmpty() {

--- a/src/main/java/com/glodblock/github/network/SPacketMEItemInvUpdate.java
+++ b/src/main/java/com/glodblock/github/network/SPacketMEItemInvUpdate.java
@@ -1,7 +1,6 @@
 package com.glodblock.github.network;
 
 import java.io.IOException;
-import java.nio.BufferOverflowException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -14,7 +13,6 @@ import appeng.util.item.AEItemStack;
 import com.glodblock.github.client.gui.GuiFluidCraftConfirm;
 import com.glodblock.github.client.gui.GuiItemMonitor;
 import com.glodblock.github.client.gui.GuiLevelMaintainer;
-import com.glodblock.github.common.Config;
 
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
@@ -83,12 +81,8 @@ public class SPacketMEItemInvUpdate implements IMessage {
         this.resort = resort;
     }
 
-    public void appendItem(final IAEItemStack is) throws BufferOverflowException {
-        if (list.size() <= Config.packetSize) {
-            list.add(is);
-        } else {
-            throw new BufferOverflowException();
-        }
+    public void appendItem(final IAEItemStack is) {
+        list.add(is);
     }
 
     public boolean isEmpty() {

--- a/src/main/java/com/glodblock/github/network/SPacketMEUpdateBuffer.java
+++ b/src/main/java/com/glodblock/github/network/SPacketMEUpdateBuffer.java
@@ -1,0 +1,130 @@
+package com.glodblock.github.network;
+
+import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.api.storage.data.IAEItemStack;
+
+import com.glodblock.github.FluidCraft;
+import com.glodblock.github.common.Config;
+
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.PlayerEvent;
+
+/**
+ * Only should exist on the server side! Schedules packets to be sent every `packetRate` ms.
+ */
+public class SPacketMEUpdateBuffer {
+
+    private static ScheduledExecutorService executor;
+    private static ScheduledFuture<?> task;
+
+    private static final Map<EntityPlayerMP, LinkedHashSet<IAEItemStack>> itemBuffer = new HashMap<>();
+
+    private static final Map<EntityPlayerMP, LinkedHashSet<IAEFluidStack>> fluidBuffer = new HashMap<>();
+
+    public static void init() {
+        executor = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread thread = new Thread(r);
+            thread.setName("AE2FC Network worker");
+            thread.setDaemon(true);
+            thread.setPriority(6);
+            return thread;
+        });
+        task = executor
+                .scheduleAtFixedRate(SPacketMEUpdateBuffer::sendBuffer, 0, Config.packetRate, TimeUnit.MILLISECONDS);
+    }
+
+    public static void disable() {
+        task.cancel(false);
+        executor.shutdown();
+    }
+
+    public static void scheduleItemUpdate(EntityPlayerMP player, List<IAEItemStack> stacks) {
+        synchronized (itemBuffer) {
+            if (!itemBuffer.containsKey(player)) {
+                itemBuffer.put(player, new LinkedHashSet<>(1024));
+            }
+            LinkedHashSet<IAEItemStack> buffer = itemBuffer.get(player);
+            stacks.forEach(s -> buffer.add(s.copy()));
+        }
+    }
+
+    public static void scheduleFluidUpdate(EntityPlayerMP player, List<IAEFluidStack> stacks) {
+        synchronized (itemBuffer) {
+            if (!fluidBuffer.containsKey(player)) {
+                fluidBuffer.put(player, new LinkedHashSet<>(1024));
+            }
+            LinkedHashSet<IAEFluidStack> buffer = fluidBuffer.get(player);
+            stacks.forEach(s -> buffer.add(s.copy()));
+        }
+    }
+
+    public static void sendBuffer() {
+        synchronized (itemBuffer) {
+            itemBuffer.forEach((player, updates) -> {
+                if (updates.isEmpty()) return;
+                int i = 0;
+                SPacketMEItemInvUpdate packet = new SPacketMEItemInvUpdate(false);
+                Iterator<IAEItemStack> it = updates.iterator();
+                while (it.hasNext()) {
+                    if (i < Config.packetSize) {
+                        packet.appendItem(it.next());
+                        it.remove();
+                        i++;
+                    } else {
+                        FluidCraft.proxy.netHandler.sendTo(packet, player);
+                        packet = new SPacketMEItemInvUpdate(false);
+                        i = 0;
+                    }
+                }
+                packet.setResort(true);
+                FluidCraft.proxy.netHandler.sendTo(packet, player);
+            });
+            fluidBuffer.forEach((player, updates) -> {
+                if (updates.isEmpty()) return;
+                int i = 0;
+                SPacketMEFluidInvUpdate packet = new SPacketMEFluidInvUpdate(false);
+                Iterator<IAEFluidStack> it = updates.iterator();
+                while (it.hasNext()) {
+                    if (i < Config.packetSize) {
+                        packet.appendFluid(it.next());
+                        it.remove();
+                        i++;
+                    } else {
+                        FluidCraft.proxy.netHandler.sendTo(packet, player);
+                        packet = new SPacketMEFluidInvUpdate(false);
+                        i = 0;
+                    }
+                }
+                packet.setResort(true);
+                FluidCraft.proxy.netHandler.sendTo(packet, player);
+            });
+
+        }
+    }
+
+    public static void clear(EntityPlayerMP player) {
+        synchronized (itemBuffer) {
+            if (itemBuffer.containsKey(player)) {
+                itemBuffer.get(player).clear();
+            }
+            if (fluidBuffer.containsKey(player)) {
+                fluidBuffer.get(player).clear();
+            }
+        }
+    }
+
+    @SubscribeEvent
+    public void onPlayerLeave(PlayerEvent.PlayerLoggedOutEvent event) {
+        if (event.player instanceof EntityPlayerMP) {
+            clear((EntityPlayerMP) event.player);
+        }
+    }
+}

--- a/src/main/java/com/glodblock/github/proxy/CommonProxy.java
+++ b/src/main/java/com/glodblock/github/proxy/CommonProxy.java
@@ -11,8 +11,10 @@ import com.glodblock.github.common.Config;
 import com.glodblock.github.common.tile.TileWalrus;
 import com.glodblock.github.inventory.external.AEFluidInterfaceHandler;
 import com.glodblock.github.loader.ItemAndBlockHolder;
+import com.glodblock.github.network.SPacketMEUpdateBuffer;
 import com.glodblock.github.util.ModAndClassUtil;
 
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
@@ -27,6 +29,7 @@ public class CommonProxy {
 
     public void init(FMLInitializationEvent event) {
         this.registerMovables();
+        FMLCommonHandler.instance().bus().register(SPacketMEUpdateBuffer.class);
     }
 
     public void postInit(FMLPostInitializationEvent event) {


### PR DESCRIPTION
1. Item and fluid packets are separated to their own classes, as they are not even allowed to be mixed together in the first place. This will enforce a strict separation of the two.

2. New network worker thread for handling ME inventory updates. Instead of creating packets directly, classes should schedule packet(s) to be sent at the next 50ms boundary. The packet has a limit of 256 items to prevent killing the client, but this can be changed in the config. In fact, the packet send rate is also configurable.

3. Upon opening a terminal GUI, ME update packets are split. Only the last received packet will trigger a terminal sorting, so if the ME system is large, it may take several seconds (!) to load all the items.