### PR TITLE
Quantum fluid cell fix

### DIFF
--- a/src/main/java/com/glodblock/github/loader/ItemAndBlockHolder.java
+++ b/src/main/java/com/glodblock/github/loader/ItemAndBlockHolder.java
@@ -81,7 +81,7 @@ public class ItemAndBlockHolder {
             NameConst.ITEM_QUANTUM_FLUID_STORAGE,
             Integer.MAX_VALUE / 16,
             8,
-            5,
+            1,
             4.5).register();
     public static ItemFluidExtremeStorageCell SINGULARITY_CELL = new ItemFluidExtremeStorageCell(
             NameConst.ITEM_SINGULARITY_FLUID_STORAGE,


### PR DESCRIPTION
Changes the quantum fluid cell to only have one item type, same as the quantum tank it is based on. This also brings it in line with the item option.

The next step will be to discuss and add recipes for this cell and the singularity one. The initial proposals were in here https://github.com/GTNewHorizons/NewHorizonsCoreMod/pull/537. (but there was a feature freeze, no agreement on the recipe, and this fix was missing too)