### PR TITLE
Add null check when determining potential tanks to import

### DIFF
--- a/src/main/java/com/glodblock/github/common/parts/PartFluidImportBus.java
+++ b/src/main/java/com/glodblock/github/common/parts/PartFluidImportBus.java
@@ -68,11 +68,15 @@ public class PartFluidImportBus extends FCSharedFluidBus {
         if (te instanceof IFluidHandler) {
             try {
                 final IFluidHandler fh = (IFluidHandler) te;
-                final IMEMonitor<IAEFluidStack> inv = this.getProxy().getStorage().getFluidInventory();
+                FluidTankInfo[] tanksInfo = fh.getTankInfo(this.getSide().getOpposite());
+                if (tanksInfo == null) {
+                    return TickRateModulation.SLOWER;
+                }
 
+                final IMEMonitor<IAEFluidStack> inv = this.getProxy().getStorage().getFluidInventory();
                 int maxDrain = this.calculateAmountToSend();
                 boolean drained = false;
-                FluidTankInfo[] tanksInfo = fh.getTankInfo(this.getSide().getOpposite());
+
                 for (FluidTankInfo tankInfo : tanksInfo) {
                     if (tankInfo.fluid == null) {
                         continue;


### PR DESCRIPTION
It seems that implementers of IFluidHandler sometimes return null in `getTankInfo()` (is that legal?), so this adds a check for that before doing the bus work. Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13291