### PR TITLE
Add null check for tanks

### DIFF
--- a/src/main/java/com/glodblock/github/inventory/FluidConvertingInventoryAdaptor.java
+++ b/src/main/java/com/glodblock/github/inventory/FluidConvertingInventoryAdaptor.java
@@ -278,9 +278,17 @@ public class FluidConvertingInventoryAdaptor extends InventoryAdaptor {
 
     @Override
     public Iterator<ItemSlot> iterator() {
+        FluidTankInfo[] info = null;
+        if (invFluids != null) {
+            info = invFluids.getTankInfo(side);
+        }
+        // Null check is needed because some tank infos return null (EIO conduits...)
+        if (info == null) {
+            info = new FluidTankInfo[0];
+        }
         return new SlotIterator(
-                invFluids != null ? invFluids.getTankInfo(side) : new FluidTankInfo[0],
-                invItems != null ? invItems.iterator() : Collections.emptyIterator());
+            info,
+            invItems != null ? invItems.iterator() : Collections.emptyIterator());
     }
 
     private IFluidHandler getSideFluid(ForgeDirection direction) {
@@ -466,7 +474,7 @@ public class FluidConvertingInventoryAdaptor extends InventoryAdaptor {
 
         @Override
         public boolean hasNext() {
-            return nextSlotIndex < tanks.length || itemSlots.hasNext();
+            return itemSlots.hasNext() || nextSlotIndex < tanks.length;
         }
 
         @Override

--- a/src/main/java/com/glodblock/github/inventory/FluidConvertingInventoryAdaptor.java
+++ b/src/main/java/com/glodblock/github/inventory/FluidConvertingInventoryAdaptor.java
@@ -286,9 +286,7 @@ public class FluidConvertingInventoryAdaptor extends InventoryAdaptor {
         if (info == null) {
             info = new FluidTankInfo[0];
         }
-        return new SlotIterator(
-            info,
-            invItems != null ? invItems.iterator() : Collections.emptyIterator());
+        return new SlotIterator(info, invItems != null ? invItems.iterator() : Collections.emptyIterator());
     }
 
     private IFluidHandler getSideFluid(ForgeDirection direction) {


### PR DESCRIPTION
Some `IFluidHandlers` return null for getTankInfo(), so a null check is needed.

Also switches the item check around because its more likely for an item to exist.

Attempt to fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13252