### PR TITLE
Fix fluid export bus voiding fluids on crafting only mode

### DIFF
--- a/src/main/java/com/glodblock/github/common/parts/PartFluidExportBus.java
+++ b/src/main/java/com/glodblock/github/common/parts/PartFluidExportBus.java
@@ -119,40 +119,41 @@ public class PartFluidExportBus extends FCSharedFluidBus implements ICraftingReq
                     IAEFluidStack fluid = AEFluidStack
                             .create(ItemFluidPacket.getFluidStack(getInv().getStackInSlot(slotToExport)));
                     if (fluid != null) {
-                        boolean isAllowed = true;
-
-                        final IAEFluidStack toExtract = fluid.copy();
-
-                        toExtract.setStackSize(this.calculateAmountToSend());
-
+                        fluid.setStackSize(this.calculateAmountToSend());
                         if (this.craftOnly()) {
-                            isAllowed = this.craftingTracker.handleCrafting(
+                            this.didSomething = this.craftingTracker.handleCrafting(
                                     i,
-                                    toExtract.getStackSize(),
-                                    ItemFluidDrop.newAeStack(toExtract),
+                                    fluid.getStackSize(),
+                                    ItemFluidDrop.newAeStack(fluid),
                                     destination,
                                     this.getTile().getWorldObj(),
                                     this.getProxy().getGrid(),
                                     cg,
                                     this.source);
+                            continue;
                         }
-
-                        int space = fh.fill(this.getSide().getOpposite(), toExtract.getFluidStack(), false);
-                        toExtract.setStackSize(space);
-                        final IAEFluidStack real = inv.extractItems(toExtract, Actionable.MODULATE, this.source);
-                        if (real != null && isAllowed) {
+                        // Find out how much to push
+                        final IAEFluidStack toPush = fluid.copy();
+                        final int amtToInsert = fh.fill(this.getSide().getOpposite(), toPush.getFluidStack(), false);
+                        toPush.setStackSize(amtToInsert);
+                        // Extract from the ME system. This might not be the same amount we actually send...
+                        final IAEFluidStack real = inv.extractItems(toPush, Actionable.MODULATE, this.source);
+                        if (real != null) {
                             int realInserted = fh.fill(this.getSide().getOpposite(), real.getFluidStack(), true);
                             if (realInserted < real.getStackSize()) {
-                                toExtract.setStackSize(real.getStackSize() - realInserted);
-                                inv.injectItems(toExtract, Actionable.MODULATE, this.source);
+                                // Could not use the entirety of the amount we extracted, so put it back.
+                                // This can result in voiding fluids if there's nowhere for the fluids to go.
+                                fluid.setStackSize(real.getStackSize() - realInserted);
+                                inv.injectItems(fluid, Actionable.MODULATE, this.source);
                             }
                             this.fluidToSend -= realInserted;
                             didSomething = true;
                         } else if (this.isCraftingEnabled()) {
-                            this.craftingTracker.handleCrafting(
+                            // If we didn't send anything, try crafting it if we can.
+                            this.didSomething = this.craftingTracker.handleCrafting(
                                     i,
-                                    toExtract.getStackSize(),
-                                    ItemFluidDrop.newAeStack(toExtract),
+                                    fluid.getStackSize(),
+                                    ItemFluidDrop.newAeStack(fluid),
                                     destination,
                                     this.getTile().getWorldObj(),
                                     this.getProxy().getGrid(),


### PR DESCRIPTION
The Fluid Export Bus was voiding fluids on craft only mode because it tried to craft it, and decided to continue with the normal export logic: Extract fluid from ME system and fill the tank.

Unfortunately, there was a condition that prevented the extracted fluid from going anywhere depending on craft only mode, so it got voided.

Commit fixes this by skipping the normal extract logic if set to craft only.

The amount must be simulated before extracting from the ME system. This helps prevent a scenario where we cannot insert the fluid back (such as when we have a fluid storage bus on Extract Only). In rare scenarios this may still void some fluids.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12966