### PR TITLE
Allow all 63 partition items to be used for fluid cells

### DIFF
--- a/src/main/java/com/glodblock/github/common/storage/FluidCellInventoryHandler.java
+++ b/src/main/java/com/glodblock/github/common/storage/FluidCellInventoryHandler.java
@@ -32,7 +32,6 @@ public class FluidCellInventoryHandler extends MEInventoryHandler<IAEFluidStack>
                 final ItemStack is = config.getStackInSlot(x);
                 if (Util.getFluidFromItem(is) != null) {
                     priorityList.add(AEFluidStack.create(Util.getFluidFromItem(is)));
-                    break;
                 }
             }
             if (!priorityList.isEmpty()) {


### PR DESCRIPTION
Previously, only one partition item was allowed. This fix will have the cell consider all 63 slots. If you configure more than 1 or 5 cell slots, it works as expected - up to 1 or 5 of the whitelisted fluids can be stored at a time.

This will degrade performance slightly.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12970