### PR TITLE
Add support for the Advanced Blocking Card to Dual Interfaces

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@
 
 dependencies {
     api('com.github.GTNewHorizons:NotEnoughItems:2.3.45-GTNH:dev')
-    api('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-195-GTNH:dev')
+    api('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-203-GTNH:dev')
     api('curse.maven:cofh-core-69162:2388751')
     api('com.github.GTNewHorizons:waila:1.5.24:dev')
     compileOnly('com.github.GTNewHorizons:ExtraCells2:2.5.33:dev') { transitive = false }

--- a/src/main/java/com/glodblock/github/client/gui/GuiDualInterface.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiDualInterface.java
@@ -6,10 +6,7 @@ import net.minecraft.util.StatCollector;
 
 import org.lwjgl.input.Mouse;
 
-import appeng.api.config.InsertionMode;
-import appeng.api.config.Settings;
-import appeng.api.config.SidelessMode;
-import appeng.api.config.YesNo;
+import appeng.api.config.*;
 import appeng.client.gui.implementations.GuiUpgradeable;
 import appeng.client.gui.widgets.GuiImgButton;
 import appeng.client.gui.widgets.GuiTabButton;
@@ -38,6 +35,7 @@ public class GuiDualInterface extends GuiUpgradeable {
     private GuiToggleButton interfaceMode;
     private GuiImgButton insertionMode;
     private GuiImgButton sidelessMode;
+    private GuiImgButton advancedBlockingMode;
     private final IInterfaceHost host;
 
     public GuiDualInterface(InventoryPlayer inventoryPlayer, IInterfaceHost te) {
@@ -85,10 +83,17 @@ public class GuiDualInterface extends GuiUpgradeable {
                 InsertionMode.DEFAULT);
         this.buttonList.add(this.insertionMode);
 
+        this.advancedBlockingMode = new GuiImgButton(
+                this.guiLeft - 18,
+                this.guiTop + 62,
+                Settings.ADVANCED_BLOCKING_MODE,
+                AdvancedBlockingMode.DEFAULT);
+        this.buttonList.add(this.advancedBlockingMode);
+
         if (isTile()) {
             this.sidelessMode = new GuiImgButton(
                     this.guiLeft - 18,
-                    this.guiTop + 62,
+                    this.guiTop + 80,
                     Settings.SIDELESS_MODE,
                     SidelessMode.SIDELESS);
             this.buttonList.add(this.sidelessMode);
@@ -110,7 +115,9 @@ public class GuiDualInterface extends GuiUpgradeable {
         if (this.sidelessMode != null) {
             this.sidelessMode.set(((ContainerDualInterface) this.cvb).getSidelessMode());
         }
-
+        if (this.advancedBlockingMode != null) {
+            this.advancedBlockingMode.set(((ContainerDualInterface) this.cvb).getAdvancedBlockingMode());
+        }
         this.fontRendererObj.drawString(
                 getGuiDisplayName(StatCollector.translateToLocal(NameConst.GUI_FLUID_INTERFACE)),
                 8,
@@ -159,6 +166,10 @@ public class GuiDualInterface extends GuiUpgradeable {
         }
         if (btn == this.sidelessMode) {
             NetworkHandler.instance.sendToServer(new PacketConfigButton(this.sidelessMode.getSetting(), backwards));
+        }
+        if (btn == this.advancedBlockingMode) {
+            NetworkHandler.instance
+                    .sendToServer(new PacketConfigButton(this.advancedBlockingMode.getSetting(), backwards));
         }
     }
 

--- a/src/main/java/com/glodblock/github/inventory/FluidConvertingInventoryAdaptor.java
+++ b/src/main/java/com/glodblock/github/inventory/FluidConvertingInventoryAdaptor.java
@@ -13,8 +13,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidHandler;
 
-import appeng.api.config.FuzzyMode;
-import appeng.api.config.InsertionMode;
+import appeng.api.config.*;
 import appeng.api.parts.IPart;
 import appeng.helpers.DualityInterface;
 import appeng.helpers.IInterfaceHost;
@@ -47,20 +46,23 @@ public class FluidConvertingInventoryAdaptor extends InventoryAdaptor {
 
     // facing is the target TE direction
     // |T|-facing->|I|
-    public FluidConvertingInventoryAdaptor(@Nullable InventoryAdaptor invItems, @Nullable IFluidHandler invFluids,
-            ForgeDirection facing, BlockPos pos, boolean isOnmi) {
+    public FluidConvertingInventoryAdaptor(TileEntity te, @Nullable InventoryAdaptor invItems,
+            @Nullable IFluidHandler invFluids, ForgeDirection facing, BlockPos pos, boolean isOnmi) {
         this.invItems = invItems;
         this.invFluids = invFluids;
         this.side = facing;
         this.posInterface = pos;
         this.onmi = isOnmi;
         this.selfInterface = getInterfaceTE(pos.getTileEntity(), facing.getOpposite());
+        this.targetInterface = getInterfaceTE(te, facing);
     }
 
     private final InventoryAdaptor invItems;
     private final IFluidHandler invFluids;
     private final ForgeDirection side;
     private final BlockPos posInterface;
+    @Nullable
+    private final IInterfaceHost targetInterface;
     @Nullable
     private final IInterfaceHost selfInterface;
     private final boolean onmi;
@@ -96,7 +98,7 @@ public class FluidConvertingInventoryAdaptor extends InventoryAdaptor {
         if (inter instanceof TileInterface) {
             onmi = ((TileInterface) inter).getTargets().size() > 1;
         }
-        return new FluidConvertingInventoryAdaptor(item, fluid, face, new BlockPos(inter), onmi);
+        return new FluidConvertingInventoryAdaptor(capProvider, item, fluid, face, new BlockPos(inter), onmi);
     }
 
     public ItemStack addItems(ItemStack toBeAdded, InsertionMode insertionMode) {
@@ -361,6 +363,11 @@ public class FluidConvertingInventoryAdaptor extends InventoryAdaptor {
     private int checkItemFluids(IFluidHandler tank, InventoryAdaptor inv, ForgeDirection direction) {
         if (tank == null && inv == null) {
             return 2;
+        }
+        if (targetInterface != null && targetInterface.getInstalledUpgrades(Upgrades.ADVANCED_BLOCKING) > 0
+                && targetInterface instanceof IDualHost
+                && !((IDualHost) targetInterface).getDualityFluid().getFluidInventory().getStorageList().isEmpty()) {
+            return 1;
         }
         if (tank != null && tank.getTankInfo(direction) != null) {
             List<FluidTankInfo[]> tankInfos = new LinkedList<>();

--- a/src/main/java/com/glodblock/github/proxy/CommonProxy.java
+++ b/src/main/java/com/glodblock/github/proxy/CommonProxy.java
@@ -39,9 +39,10 @@ public class CommonProxy {
         }
         Upgrades.CRAFTING.registerItem(new ItemStack(ItemAndBlockHolder.FLUID_INTERFACE), 1);
         Upgrades.CRAFTING.registerItem(new ItemStack(ItemAndBlockHolder.INTERFACE), 1);
+        Upgrades.ADVANCED_BLOCKING.registerItem(new ItemStack(ItemAndBlockHolder.FLUID_INTERFACE), 1);
+        Upgrades.ADVANCED_BLOCKING.registerItem(new ItemStack(ItemAndBlockHolder.INTERFACE), 1);
         Upgrades.CAPACITY.registerItem(new ItemStack(ItemAndBlockHolder.FLUID_STORAGE_BUS), 5);
         Upgrades.INVERTER.registerItem(new ItemStack(ItemAndBlockHolder.FLUID_STORAGE_BUS), 1);
-
         if (Config.fluidIOBus) {
             Upgrades.CAPACITY.registerItem(new ItemStack(ItemAndBlockHolder.FLUID_EXPORT_BUS), 2);
             Upgrades.CAPACITY.registerItem(new ItemStack(ItemAndBlockHolder.FLUID_IMPORT_BUS), 2);


### PR DESCRIPTION
Behavior: The Dual Interface acts in the same way as the regular ME interface when the advanced blocking card is used, but has an additional check for fluids on top of items contained in the ME system.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12950