### PR TITLE
More ec2 mappings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1678003329
+//version: 1683373797
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -6,29 +6,25 @@
  */
 
 
-import com.diffplug.blowdryer.Blowdryer
-import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import com.gtnewhorizons.retrofuturagradle.ObfuscationAttribute
 import com.gtnewhorizons.retrofuturagradle.mcp.ReobfuscatedJar
 import com.gtnewhorizons.retrofuturagradle.minecraft.RunMinecraftTask
+import com.gtnewhorizons.retrofuturagradle.util.Distribution
 import com.matthewprenger.cursegradle.CurseArtifact
 import com.matthewprenger.cursegradle.CurseRelation
 import com.modrinth.minotaur.dependencies.ModDependency
 import com.modrinth.minotaur.dependencies.VersionDependency
-import cpw.mods.fml.relauncher.Side
-import org.gradle.api.tasks.options.Option;
 import org.gradle.internal.logging.text.StyledTextOutput.Style
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import org.gradle.internal.xml.XmlTransformer
-import org.jetbrains.gradle.ext.*
+import org.jetbrains.gradle.ext.Application
+import org.jetbrains.gradle.ext.Gradle
 
+import javax.inject.Inject
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
-import java.util.zip.ZipEntry
-import java.util.zip.ZipOutputStream
-import javax.inject.Inject
 
 buildscript {
     repositories {
@@ -65,22 +61,26 @@ plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.8.0' apply false
     id 'org.jetbrains.kotlin.kapt' version '1.8.0' apply false
     id 'com.google.devtools.ksp' version '1.8.0-1.0.9' apply false
-    id 'org.ajoberstar.grgit' version '4.1.1' // 4.1.1 is the last jvm8 supporting version ,unused, available for addon.gradle
-    id 'com.github.johnrengelman.shadow' version '7.1.2' apply false
-    id 'com.palantir.git-version' version '0.13.0' apply false // 0.13.0 is the last jvm8 supporting version
-    id 'de.undercouch.download' version '5.3.0'
+    id 'org.ajoberstar.grgit' version '4.1.1' // 4.1.1 is the last jvm8 supporting version, unused, available for addon.gradle
+    id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
+    id 'com.palantir.git-version' version '3.0.0' apply false
+    id 'de.undercouch.download' version '5.4.0'
     id 'com.github.gmazzo.buildconfig' version '3.1.0' apply false // Unused, available for addon.gradle
-    id 'com.diffplug.spotless' version '6.7.2' apply false
+    id 'com.diffplug.spotless' version '6.13.0' apply false // 6.13.0 is the last jvm8 supporting version
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.2.3'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.7'
 }
+
+print("You might want to check out './gradlew :faq' if your build fails.\n")
+
 boolean settingsupdated = verifySettingsGradle()
 settingsupdated = verifyGitAttributes() || settingsupdated
 if (settingsupdated)
     throw new GradleException("Settings has been updated, please re-run task.")
 
-if (project.file('.git/HEAD').isFile()) {
+// In submodules, .git is a file pointing to the real git dir
+if (project.file('.git/HEAD').isFile() || project.file('.git').isFile()) {
     apply plugin: 'com.palantir.git-version'
 }
 
@@ -132,7 +132,7 @@ propertyDefaultIfUnset("enableGenericInjection", false) // On by default for new
 // this is meant to be set using the user wide property file. by default we do nothing.
 propertyDefaultIfUnset("ideaOverrideBuildType", "") // Can be nothing, "gradle" or "idea"
 
-project.extensions.add(Blowdryer, "Blowdryer", Blowdryer) // Make blowdryer available in "apply from:" scripts
+project.extensions.add(com.diffplug.blowdryer.Blowdryer, "Blowdryer", com.diffplug.blowdryer.Blowdryer) // Make blowdryer available in "apply from:" scripts
 if (!disableSpotless) {
     apply plugin: 'com.diffplug.spotless'
     apply from: Blowdryer.file('spotless.gradle')
@@ -158,6 +158,14 @@ java {
     if (!noPublishedSources) {
         withSourcesJar()
     }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = "UTF-8"
+}
+
+tasks.withType(ScalaCompile).configureEach {
+    options.encoding = "UTF-8"
 }
 
 pluginManager.withPlugin('org.jetbrains.kotlin.jvm') {
@@ -193,6 +201,14 @@ configurations {
         canBeConsumed = false
         canBeResolved = false
     }
+
+    create("devOnlyNonPublishable") {
+        description = "Runtime and compiletime dependencies that are not published alongside the jar (compileOnly + runtimeOnlyNonPublishable)"
+        canBeConsumed = false
+        canBeResolved = false
+    }
+    compileOnly.extendsFrom(devOnlyNonPublishable)
+    runtimeOnlyNonPublishable.extendsFrom(devOnlyNonPublishable)
 }
 
 if (enableModernJavaSyntax.toBoolean()) {
@@ -206,6 +222,8 @@ if (enableModernJavaSyntax.toBoolean()) {
 
     dependencies {
         annotationProcessor 'com.github.bsideup.jabel:jabel-javac-plugin:1.0.0'
+        // workaround for https://github.com/bsideup/jabel/issues/174
+        annotationProcessor 'net.java.dev.jna:jna-platform:5.13.0'
         compileOnly('com.github.bsideup.jabel:jabel-javac-plugin:1.0.0') {
             transitive = false // We only care about the 1 annotation class
         }
@@ -391,14 +409,12 @@ minecraft {
 
     username = developmentEnvironmentUserName.toString()
 
-    lwjgl3Version = "3.3.2-SNAPSHOT"
+    lwjgl3Version = "3.3.2"
 
     // Enable assertions in the current mod
     extraRunJvmArguments.add("-ea:${modGroup}")
 
     if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
-        extraTweakClasses.add("org.spongepowered.asm.launch.MixinTweaker")
-
         if (usesMixinDebug.toBoolean()) {
             extraRunJvmArguments.addAll([
                 "-Dmixin.debug.countInjections=true",
@@ -513,14 +529,6 @@ repositories {
         url = "http://jenkins.usrv.eu:8081/nexus/content/groups/public/"
         allowInsecureProtocol = true
     }
-    if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
-        if (usesMixinDebug.toBoolean()) {
-            maven {
-                name = "Fabric Maven"
-                url = "https://maven.fabricmc.net/"
-            }
-        }
-    }
     maven {
         name 'sonatype'
         url 'https://oss.sonatype.org/content/repositories/snapshots/'
@@ -559,26 +567,46 @@ repositories {
     }
 }
 
+def mixinProviderGroup = "io.github.legacymoddingmc"
+def mixinProviderModule = "unimixins"
+def mixinProviderVersion = "0.1.6"
+def mixinProviderSpecNoClassifer = "${mixinProviderGroup}:${mixinProviderModule}:${mixinProviderVersion}"
+def mixinProviderSpec = "${mixinProviderSpecNoClassifer}:dev"
+
 dependencies {
     if (usesMixins.toBoolean()) {
         annotationProcessor('org.ow2.asm:asm-debug-all:5.0.3')
         annotationProcessor('com.google.guava:guava:24.1.1-jre')
         annotationProcessor('com.google.code.gson:gson:2.8.6')
-        annotationProcessor('com.gtnewhorizon:gtnhmixins:2.1.13:processor')
+        annotationProcessor(mixinProviderSpec)
         if (usesMixinDebug.toBoolean()) {
             runtimeOnlyNonPublishable('org.jetbrains:intellij-fernflower:1.2.1.16')
         }
     }
-    if (usesMixins.toBoolean() || forceEnableMixins.toBoolean()) {
-        implementation('com.gtnewhorizon:gtnhmixins:2.1.13')
+    if (usesMixins.toBoolean()) {
+        implementation(mixinProviderSpec)
+    } else if (forceEnableMixins.toBoolean()) {
+        runtimeOnlyNonPublishable(mixinProviderSpec)
     }
 }
 
 pluginManager.withPlugin('org.jetbrains.kotlin.kapt') {
     if (usesMixins.toBoolean()) {
         dependencies {
-            kapt('com.gtnewhorizon:gtnhmixins:2.1.13:processor')
+            kapt(mixinProviderSpec)
         }
+    }
+}
+
+// Replace old mixin mods with unimixins
+// https://docs.gradle.org/8.0.2/userguide/resolution_rules.html#sec:substitution_with_classifier
+configurations.all {
+    resolutionStrategy.dependencySubstitution {
+        substitute module('com.gtnewhorizon:gtnhmixins') using module(mixinProviderSpecNoClassifer) withClassifier("dev") because("Unimixins replaces other mixin mods")
+        substitute module('com.github.GTNewHorizons:Mixingasm') using module(mixinProviderSpecNoClassifer) withClassifier("dev") because("Unimixins replaces other mixin mods")
+        substitute module('com.github.GTNewHorizons:SpongePoweredMixin') using module(mixinProviderSpecNoClassifer) withClassifier("dev") because("Unimixins replaces other mixin mods")
+        substitute module('com.github.GTNewHorizons:SpongeMixins') using module(mixinProviderSpecNoClassifer) withClassifier("dev") because("Unimixins replaces other mixin mods")
+        substitute module('io.github.legacymoddingmc:unimixins') using module(mixinProviderSpecNoClassifer) withClassifier("dev") because("Our previous unimixins upload was missing the dev classifier")
     }
 }
 
@@ -695,13 +723,13 @@ ext.java17PatchDependenciesCfg = configurations.create("java17PatchDependencies"
 }
 
 dependencies {
-    def lwjgl3ifyVersion = '1.1.35'
+    def lwjgl3ifyVersion = '1.3.5'
     def asmVersion = '9.4'
     if (modId != 'lwjgl3ify') {
         java17Dependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}")
     }
     if (modId != 'hodgepodge') {
-        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.0.40')
+        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.8')
     }
 
     java17PatchDependencies('net.minecraft:launchwrapper:1.15') {transitive = false}
@@ -775,7 +803,7 @@ public abstract class RunHotswappableMinecraftTask extends RunMinecraftTask {
     public boolean setEnableHotswap(boolean enable) { enableHotswap = enable }
 
     @Inject
-    public RunHotswappableMinecraftTask(Side side, String superTask, org.gradle.api.invocation.Gradle gradle) {
+    public RunHotswappableMinecraftTask(Distribution side, String superTask, org.gradle.api.invocation.Gradle gradle) {
         super(side, gradle)
 
         this.lwjglVersion = 3
@@ -784,7 +812,7 @@ public abstract class RunHotswappableMinecraftTask extends RunMinecraftTask {
         this.extraJvmArgs.addAll(project.provider(() -> enableHotswap ? project.hotswapJvmArgs : []))
 
         this.classpath(project.java17PatchDependenciesCfg)
-        if (side == Side.CLIENT) {
+        if (side == Distribution.CLIENT) {
             this.classpath(project.minecraftTasks.lwjgl3Configuration)
         }
         // Use a raw provider instead of map to not create a dependency on the task
@@ -793,14 +821,10 @@ public abstract class RunHotswappableMinecraftTask extends RunMinecraftTask {
             !file.path.contains("2.9.4-nightly-20150209") // Remove lwjgl2
         }
         this.classpath(project.java17DependenciesCfg)
-
-        if (!(project.usesMixins.toBoolean() || project.forceEnableMixins.toBoolean())) {
-            this.extraArgs.addAll("--tweakClass", "org.spongepowered.asm.launch.MixinTweaker")
-        }
     }
 }
 
-def runClient17Task = tasks.register("runClient17", RunHotswappableMinecraftTask, Side.CLIENT, "runClient")
+def runClient17Task = tasks.register("runClient17", RunHotswappableMinecraftTask, Distribution.CLIENT, "runClient")
 runClient17Task.configure {
     setup(project)
     group = "Modded Minecraft"
@@ -811,7 +835,7 @@ runClient17Task.configure {
     userUUID = minecraft.userUUID
 }
 
-def runServer17Task = tasks.register("runServer17", RunHotswappableMinecraftTask, Side.SERVER, "runServer")
+def runServer17Task = tasks.register("runServer17", RunHotswappableMinecraftTask, Distribution.DEDICATED_SERVER, "runServer")
 runServer17Task.configure {
     setup(project)
     group = "Modded Minecraft"
@@ -852,11 +876,6 @@ tasks.named("jar", Jar).configure {
 }
 
 if (usesShadowedDependencies.toBoolean()) {
-    tasks.register('relocateShadowJar', ConfigureShadowRelocation) {
-        target = tasks.shadowJar
-        prefix = modGroup + ".shadow"
-        enabled = relocateShadowedDependencies.toBoolean()
-    }
     tasks.named("shadowJar", ShadowJar).configure {
         manifest {
             attributes(getManifestAttributes())
@@ -872,7 +891,8 @@ if (usesShadowedDependencies.toBoolean()) {
         ]
         archiveClassifier.set('dev')
         if (relocateShadowedDependencies.toBoolean()) {
-            dependsOn(relocateShadowJar)
+            relocationPrefix = modGroup + ".shadow"
+            enableRelocation = true
         }
     }
     configurations.runtimeElements.outgoing.artifacts.clear()
@@ -1006,6 +1026,7 @@ idea {
             }
             compiler.javac {
                 afterEvaluate {
+                    javacAdditionalOptions = "-encoding utf8"
                     moduleJavacAdditionalOptions = [
                         (project.name + ".main"): tasks.compileJava.options.compilerArgs.collect { '"' + it + '"' }.join(' ')
                     ]
@@ -1125,7 +1146,7 @@ if (modrinthProjectId.size() != 0 && System.getenv("MODRINTH_TOKEN") != null) {
         }
     }
     if (usesMixins.toBoolean()) {
-        addModrinthDep("required", "project", "gtnhmixins")
+        addModrinthDep("required", "project", "unimixins")
     }
     tasks.modrinth.dependsOn(build)
     tasks.publish.dependsOn(tasks.modrinth)
@@ -1169,7 +1190,7 @@ if (curseForgeProjectId.size() != 0 && System.getenv("CURSEFORGE_TOKEN") != null
         }
     }
     if (usesMixins.toBoolean()) {
-        addCurseForgeRelation("requiredDependency", "gtnhmixins")
+        addCurseForgeRelation("requiredDependency", "unimixins")
     }
     tasks.curseforge.dependsOn(build)
     tasks.publish.dependsOn(tasks.curseforge)
@@ -1204,7 +1225,7 @@ def addCurseForgeRelation(String type, String name) {
 
 // Updating
 
-def buildscriptGradleVersion = "8.0.1"
+def buildscriptGradleVersion = "8.1.1"
 
 tasks.named('wrapper', Wrapper).configure {
     gradleVersion = buildscriptGradleVersion
@@ -1233,6 +1254,19 @@ if (!project.getGradle().startParameter.isOffline() && !Boolean.getBoolean('DISA
         if (gradle.gradleVersion != buildscriptGradleVersion) {
             out.style(Style.SuccessHeader).println("updateBuildScript can update gradle from ${gradle.gradleVersion} to ${buildscriptGradleVersion}\n")
         }
+    }
+}
+
+// If you want to add more cases to this task, implement them as arguments if total amount to print gets too large
+tasks.register('faq') {
+    group = 'GTNH Buildscript'
+    description = 'Prints frequently asked questions about building a project'
+
+    doLast {
+        print("If your build fails to fetch dependencies, they might have been deleted and replaced by newer " +
+            "versions.\nCheck if the versions you try to fetch are still on the distributing sites.\n" +
+            "The links can be found in repositories.gradle and build.gradle:repositories, " +
+            "not build.gradle:buildscript.repositories - this one is for gradle plugin metadata.")
     }
 }
 
@@ -1373,7 +1407,7 @@ static int replaceParams(File file, Map<String, String> params) {
     return 0
 }
 
-// Dependency Deobfuscation
+// Dependency Deobfuscation (Deprecated, use the new RFG API documented in dependencies.gradle)
 
 def deobf(String sourceURL) {
     try {
@@ -1415,11 +1449,7 @@ def deobfMaven(String repoURL, String mavenDep) {
 }
 
 def deobfCurse(String curseDep) {
-    try {
-        return deobfMaven("https://www.cursemaven.com/", "curse.maven:$curseDep")
-    } catch (Exception ignored) {
-        out.style(Style.Failure).println("Failed to get $curseDep from cursemaven.")
-    }
+    return dependencies.rfg.deobf("curse.maven:$curseDep")
 }
 
 // The method above is to be preferred. Use this method if the filename is not at the end of the URL.
@@ -1427,34 +1457,7 @@ def deobf(String sourceURL, String rawFileName) {
     String bon2Version = "2.5.1"
     String fileName = URLDecoder.decode(rawFileName, "UTF-8")
     String cacheDir = "$project.gradle.gradleUserHomeDir/caches"
-    String bon2Dir = "$cacheDir/forge_gradle/deobf"
-    String bon2File = "$bon2Dir/BON2-${bon2Version}.jar"
     String obfFile = "$cacheDir/modules-2/files-2.1/${fileName}.jar"
-    String deobfFile = "$cacheDir/modules-2/files-2.1/${fileName}-deobf.jar"
-
-    if (file(deobfFile).exists()) {
-        return files(deobfFile)
-    }
-
-    String mappingsVer
-    String remoteMappings = project.hasProperty('remoteMappings') ? project.remoteMappings : 'https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/'
-    if (remoteMappings) {
-        String id = "${forgeVersion.split("\\.")[3]}-$minecraftVersion"
-        String mappingsZIP = "$cacheDir/forge_gradle/maven_downloader/de/oceanlabs/mcp/mcp_snapshot_nodoc/$id/mcp_snapshot_nodoc-${id}.zip"
-
-        zipMappings(mappingsZIP, remoteMappings, bon2Dir)
-
-        mappingsVer = "snapshot_$id"
-    } else {
-        mappingsVer = "${channel}_$mappingsVersion"
-    }
-
-    download.run {
-        src "http://jenkins.usrv.eu:8081/nexus/content/repositories/releases/com/github/parker8283/BON2/$bon2Version-CUSTOM/BON2-$bon2Version-CUSTOM-all.jar"
-        dest bon2File
-        quiet true
-        overwrite false
-    }
 
     download.run {
         src sourceURL
@@ -1462,50 +1465,8 @@ def deobf(String sourceURL, String rawFileName) {
         quiet true
         overwrite false
     }
-
-    exec {
-        commandLine 'java', '-jar', bon2File, '--inputJar', obfFile, '--outputJar', deobfFile, '--mcVer', minecraftVersion, '--mappingsVer', mappingsVer, '--notch'
-        workingDir bon2Dir
-        standardOutput = new FileOutputStream("${deobfFile}.log")
-    }
-
-    return files(deobfFile)
+    return dependencies.rfg.deobf(files(obfFile))
 }
-
-def zipMappings(String zipPath, String url, String bon2Dir) {
-    File zipFile = new File(zipPath)
-    if (zipFile.exists()) {
-        return
-    }
-
-    String fieldsCache = "$bon2Dir/data/fields.csv"
-    String methodsCache = "$bon2Dir/data/methods.csv"
-
-    download.run {
-        src "${url}fields.csv"
-        dest fieldsCache
-        quiet true
-    }
-    download.run {
-        src "${url}methods.csv"
-        dest methodsCache
-        quiet true
-    }
-
-    zipFile.getParentFile().mkdirs()
-    ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zipFile))
-
-    zos.putNextEntry(new ZipEntry("fields.csv"))
-    Files.copy(Paths.get(fieldsCache), zos)
-    zos.closeEntry()
-
-    zos.putNextEntry(new ZipEntry("methods.csv"))
-    Files.copy(Paths.get(methodsCache), zos)
-    zos.closeEntry()
-
-    zos.close()
-}
-
 // Helper methods
 
 def checkPropertyExists(String propertyName) {

--- a/src/main/java/com/glodblock/github/FluidCraft.java
+++ b/src/main/java/com/glodblock/github/FluidCraft.java
@@ -2,8 +2,6 @@ package com.glodblock.github;
 
 import net.minecraft.util.ResourceLocation;
 
-import appeng.api.AEApi;
-
 import com.glodblock.github.common.Config;
 import com.glodblock.github.common.storage.FluidCellHandler;
 import com.glodblock.github.crossmod.extracells.EC2Replacer;
@@ -19,6 +17,7 @@ import com.glodblock.github.network.SPacketMEUpdateBuffer;
 import com.glodblock.github.proxy.CommonProxy;
 import com.glodblock.github.util.ModAndClassUtil;
 
+import appeng.api.AEApi;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.SidedProxy;
 import cpw.mods.fml.common.event.*;

--- a/src/main/java/com/glodblock/github/client/gui/GuiDualInterface.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiDualInterface.java
@@ -6,6 +6,16 @@ import net.minecraft.util.StatCollector;
 
 import org.lwjgl.input.Mouse;
 
+import com.glodblock.github.FluidCraft;
+import com.glodblock.github.client.gui.container.ContainerDualInterface;
+import com.glodblock.github.common.parts.PartFluidInterface;
+import com.glodblock.github.common.tile.TileFluidInterface;
+import com.glodblock.github.inventory.gui.GuiType;
+import com.glodblock.github.loader.ItemAndBlockHolder;
+import com.glodblock.github.network.CPacketSwitchGuis;
+import com.glodblock.github.util.ModAndClassUtil;
+import com.glodblock.github.util.NameConst;
+
 import appeng.api.config.*;
 import appeng.client.gui.implementations.GuiUpgradeable;
 import appeng.client.gui.widgets.GuiImgButton;
@@ -16,16 +26,6 @@ import appeng.core.localization.GuiText;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketConfigButton;
 import appeng.helpers.IInterfaceHost;
-
-import com.glodblock.github.FluidCraft;
-import com.glodblock.github.client.gui.container.ContainerDualInterface;
-import com.glodblock.github.common.parts.PartFluidInterface;
-import com.glodblock.github.common.tile.TileFluidInterface;
-import com.glodblock.github.inventory.gui.GuiType;
-import com.glodblock.github.loader.ItemAndBlockHolder;
-import com.glodblock.github.network.CPacketSwitchGuis;
-import com.glodblock.github.util.ModAndClassUtil;
-import com.glodblock.github.util.NameConst;
 
 public class GuiDualInterface extends GuiUpgradeable {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiEssentiaTerminal.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiEssentiaTerminal.java
@@ -11,11 +11,6 @@ import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
-import appeng.api.storage.data.IAEFluidStack;
-import appeng.api.storage.data.IAEItemStack;
-import appeng.client.me.SlotME;
-import appeng.client.render.AppEngRenderItem;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.client.gui.container.ContainerEssentiaMonitor;
 import com.glodblock.github.client.me.EssentiaRepo;
@@ -27,6 +22,11 @@ import com.glodblock.github.inventory.gui.GuiType;
 import com.glodblock.github.inventory.item.IWirelessTerminal;
 import com.glodblock.github.network.CPacketFluidUpdate;
 import com.glodblock.github.util.Ae2ReflectClient;
+
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.client.me.SlotME;
+import appeng.client.render.AppEngRenderItem;
 
 public class GuiEssentiaTerminal extends GuiFluidMonitor {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiFCImgButton.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiFCImgButton.java
@@ -10,10 +10,10 @@ import net.minecraft.util.StatCollector;
 
 import org.lwjgl.opengl.GL11;
 
-import appeng.client.gui.widgets.ITooltip;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.util.NameConst;
+
+import appeng.client.gui.widgets.ITooltip;
 
 public class GuiFCImgButton extends GuiButton implements ITooltip {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiFCPriority.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiFCPriority.java
@@ -4,6 +4,12 @@ import java.io.IOException;
 
 import net.minecraft.entity.player.InventoryPlayer;
 
+import com.glodblock.github.client.gui.base.FCGuiAmount;
+import com.glodblock.github.common.parts.PartFluidStorageBus;
+import com.glodblock.github.inventory.IDualHost;
+import com.glodblock.github.inventory.gui.GuiType;
+import com.glodblock.github.loader.ItemAndBlockHolder;
+
 import appeng.container.implementations.ContainerPriority;
 import appeng.core.AELog;
 import appeng.core.localization.GuiText;
@@ -12,12 +18,6 @@ import appeng.core.sync.packets.PacketValueConfig;
 import appeng.helpers.IPriorityHost;
 import appeng.util.calculators.ArithHelper;
 import appeng.util.calculators.Calculator;
-
-import com.glodblock.github.client.gui.base.FCGuiAmount;
-import com.glodblock.github.common.parts.PartFluidStorageBus;
-import com.glodblock.github.inventory.IDualHost;
-import com.glodblock.github.inventory.gui.GuiType;
-import com.glodblock.github.loader.ItemAndBlockHolder;
 
 public class GuiFCPriority extends FCGuiAmount {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiFluidAutoFiller.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiFluidAutoFiller.java
@@ -5,13 +5,13 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.util.ResourceLocation;
 
-import appeng.client.gui.AEBaseMEGui;
-import appeng.core.localization.GuiText;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.client.gui.container.ContainerFluidAutoFiller;
 import com.glodblock.github.common.tile.TileFluidAutoFiller;
 import com.glodblock.github.util.NameConst;
+
+import appeng.client.gui.AEBaseMEGui;
+import appeng.core.localization.GuiText;
 
 public class GuiFluidAutoFiller extends AEBaseMEGui {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiFluidCraftAmount.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiFluidCraftAmount.java
@@ -4,10 +4,6 @@ import net.minecraft.client.gui.GuiButton;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
 
-import appeng.api.storage.ITerminalHost;
-import appeng.container.implementations.ContainerCraftAmount;
-import appeng.core.localization.GuiText;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.client.gui.base.FCGuiAmount;
 import com.glodblock.github.common.item.ItemWirelessUltraTerminal;
@@ -19,6 +15,10 @@ import com.glodblock.github.inventory.item.IWirelessTerminal;
 import com.glodblock.github.inventory.item.WirelessPatternTerminalInventory;
 import com.glodblock.github.loader.ItemAndBlockHolder;
 import com.glodblock.github.network.CPacketCraftRequest;
+
+import appeng.api.storage.ITerminalHost;
+import appeng.container.implementations.ContainerCraftAmount;
+import appeng.core.localization.GuiText;
 
 public class GuiFluidCraftAmount extends FCGuiAmount {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiFluidCraftConfirm.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiFluidCraftConfirm.java
@@ -4,9 +4,6 @@ import java.util.*;
 
 import net.minecraft.entity.player.InventoryPlayer;
 
-import appeng.api.storage.ITerminalHost;
-import appeng.client.gui.implementations.GuiCraftConfirm;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.common.item.ItemWirelessUltraTerminal;
 import com.glodblock.github.common.parts.PartFluidPatternTerminal;
@@ -15,6 +12,9 @@ import com.glodblock.github.inventory.gui.GuiType;
 import com.glodblock.github.inventory.item.IWirelessTerminal;
 import com.glodblock.github.inventory.item.WirelessPatternTerminalInventory;
 import com.glodblock.github.network.CPacketSwitchGuis;
+
+import appeng.api.storage.ITerminalHost;
+import appeng.client.gui.implementations.GuiCraftConfirm;
 
 public class GuiFluidCraftConfirm extends GuiCraftConfirm {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiFluidCraftingWireless.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiFluidCraftingWireless.java
@@ -5,6 +5,11 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.Slot;
 
+import com.glodblock.github.client.gui.container.ContainerCraftingWireless;
+import com.glodblock.github.inventory.InventoryHandler;
+import com.glodblock.github.inventory.gui.GuiType;
+import com.glodblock.github.inventory.item.IWirelessTerminal;
+
 import appeng.api.config.ActionItems;
 import appeng.api.config.Settings;
 import appeng.client.gui.widgets.GuiImgButton;
@@ -14,11 +19,6 @@ import appeng.core.localization.GuiText;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketInventoryAction;
 import appeng.helpers.InventoryAction;
-
-import com.glodblock.github.client.gui.container.ContainerCraftingWireless;
-import com.glodblock.github.inventory.InventoryHandler;
-import com.glodblock.github.inventory.gui.GuiType;
-import com.glodblock.github.inventory.item.IWirelessTerminal;
 
 public class GuiFluidCraftingWireless extends GuiItemMonitor {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiFluidIO.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiFluidIO.java
@@ -3,16 +3,16 @@ package com.glodblock.github.client.gui;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.InventoryPlayer;
 
-import appeng.api.config.Upgrades;
-import appeng.api.storage.data.IAEFluidStack;
-import appeng.client.gui.implementations.GuiUpgradeable;
-import appeng.core.localization.GuiText;
-
 import com.glodblock.github.client.gui.container.ContainerFluidIO;
 import com.glodblock.github.common.parts.PartFluidExportBus;
 import com.glodblock.github.common.parts.PartFluidImportBus;
 import com.glodblock.github.common.parts.base.FCSharedFluidBus;
 import com.glodblock.github.util.NameConst;
+
+import appeng.api.config.Upgrades;
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.client.gui.implementations.GuiUpgradeable;
+import appeng.core.localization.GuiText;
 
 public class GuiFluidIO extends GuiUpgradeable {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiFluidInterface.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiFluidInterface.java
@@ -12,11 +12,6 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import org.lwjgl.opengl.GL11;
 
-import appeng.api.storage.data.IAEFluidStack;
-import appeng.client.gui.AEBaseGui;
-import appeng.client.gui.widgets.GuiTabButton;
-import appeng.core.localization.GuiText;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.client.gui.container.ContainerFluidInterface;
 import com.glodblock.github.common.parts.PartFluidInterface;
@@ -29,6 +24,11 @@ import com.glodblock.github.loader.ItemAndBlockHolder;
 import com.glodblock.github.network.CPacketSwitchGuis;
 import com.glodblock.github.util.NameConst;
 import com.glodblock.github.util.RenderUtil;
+
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.client.gui.AEBaseGui;
+import appeng.client.gui.widgets.GuiTabButton;
+import appeng.core.localization.GuiText;
 
 public class GuiFluidInterface extends AEBaseGui {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiFluidLevelEmitter.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiFluidLevelEmitter.java
@@ -3,6 +3,13 @@ package com.glodblock.github.client.gui;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.entity.player.InventoryPlayer;
 
+import com.glodblock.github.FluidCraft;
+import com.glodblock.github.client.gui.container.ContainerFluidLevelEmitter;
+import com.glodblock.github.common.parts.PartFluidLevelEmitter;
+import com.glodblock.github.network.CPacketValueConfig;
+import com.glodblock.github.util.Ae2ReflectClient;
+import com.glodblock.github.util.NameConst;
+
 import appeng.api.config.*;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.client.gui.implementations.GuiUpgradeable;
@@ -13,13 +20,6 @@ import appeng.core.AEConfig;
 import appeng.core.AELog;
 import appeng.core.localization.GuiColors;
 import appeng.core.localization.GuiText;
-
-import com.glodblock.github.FluidCraft;
-import com.glodblock.github.client.gui.container.ContainerFluidLevelEmitter;
-import com.glodblock.github.common.parts.PartFluidLevelEmitter;
-import com.glodblock.github.network.CPacketValueConfig;
-import com.glodblock.github.util.Ae2ReflectClient;
-import com.glodblock.github.util.NameConst;
 
 public class GuiFluidLevelEmitter extends GuiUpgradeable {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiFluidMonitor.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiFluidMonitor.java
@@ -5,17 +5,17 @@ import java.util.List;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
 
-import appeng.api.storage.ITerminalHost;
-import appeng.api.storage.data.IAEFluidStack;
-import appeng.api.storage.data.IAEItemStack;
-import appeng.core.localization.GuiText;
-import appeng.util.item.AEItemStack;
-
 import com.glodblock.github.client.gui.base.FCGuiMonitor;
 import com.glodblock.github.client.gui.container.ContainerFluidMonitor;
 import com.glodblock.github.client.me.FluidRepo;
 import com.glodblock.github.common.item.ItemFluidDrop;
 import com.glodblock.github.util.Util;
+
+import appeng.api.storage.ITerminalHost;
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.core.localization.GuiText;
+import appeng.util.item.AEItemStack;
 
 public class GuiFluidMonitor extends FCGuiMonitor<IAEFluidStack> {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiFluidPacketDecoder.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiFluidPacketDecoder.java
@@ -4,13 +4,13 @@ import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.util.ResourceLocation;
 
-import appeng.client.gui.AEBaseGui;
-import appeng.core.localization.GuiText;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.client.gui.container.ContainerFluidPacketDecoder;
 import com.glodblock.github.common.tile.TileFluidPacketDecoder;
 import com.glodblock.github.util.NameConst;
+
+import appeng.client.gui.AEBaseGui;
+import appeng.core.localization.GuiText;
 
 public class GuiFluidPacketDecoder extends AEBaseGui {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiFluidPatternEncoder.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiFluidPatternEncoder.java
@@ -13,11 +13,6 @@ import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.FluidStack;
 
-import appeng.api.storage.data.IAEItemStack;
-import appeng.client.gui.AEBaseGui;
-import appeng.client.render.AppEngRenderItem;
-import appeng.core.localization.GuiText;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.client.gui.container.ContainerFluidPatternEncoder;
 import com.glodblock.github.common.item.ItemFluidPacket;
@@ -28,6 +23,11 @@ import com.glodblock.github.inventory.slot.SlotSingleItem;
 import com.glodblock.github.network.CPacketEncodePattern;
 import com.glodblock.github.util.Ae2ReflectClient;
 import com.glodblock.github.util.NameConst;
+
+import appeng.api.storage.data.IAEItemStack;
+import appeng.client.gui.AEBaseGui;
+import appeng.client.render.AppEngRenderItem;
+import appeng.core.localization.GuiText;
 
 public class GuiFluidPatternEncoder extends AEBaseGui {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiFluidPatternExWireless.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiFluidPatternExWireless.java
@@ -2,10 +2,10 @@ package com.glodblock.github.client.gui;
 
 import net.minecraft.entity.player.InventoryPlayer;
 
+import com.glodblock.github.inventory.item.IWirelessTerminal;
+
 import appeng.container.slot.AppEngSlot;
 import appeng.container.slot.SlotDisabled;
-
-import com.glodblock.github.inventory.item.IWirelessTerminal;
 
 public class GuiFluidPatternExWireless extends GuiFluidPatternTerminalEx {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiFluidPatternTerminal.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiFluidPatternTerminal.java
@@ -6,6 +6,13 @@ import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
 
+import com.glodblock.github.client.gui.base.FCGuiEncodeTerminal;
+import com.glodblock.github.client.gui.container.ContainerFluidPatternTerminal;
+import com.glodblock.github.client.gui.container.ContainerFluidPatternWireless;
+import com.glodblock.github.inventory.item.IWirelessTerminal;
+import com.glodblock.github.util.ModAndClassUtil;
+import com.glodblock.github.util.NameConst;
+
 import appeng.api.config.ActionItems;
 import appeng.api.config.ItemSubstitution;
 import appeng.api.config.PatternBeSubstitution;
@@ -17,13 +24,6 @@ import appeng.container.slot.OptionalSlotFake;
 import appeng.container.slot.SlotFakeCraftingMatrix;
 import appeng.container.slot.SlotPatternTerm;
 import appeng.core.localization.GuiText;
-
-import com.glodblock.github.client.gui.base.FCGuiEncodeTerminal;
-import com.glodblock.github.client.gui.container.ContainerFluidPatternTerminal;
-import com.glodblock.github.client.gui.container.ContainerFluidPatternWireless;
-import com.glodblock.github.inventory.item.IWirelessTerminal;
-import com.glodblock.github.util.ModAndClassUtil;
-import com.glodblock.github.util.NameConst;
 
 public class GuiFluidPatternTerminal extends FCGuiEncodeTerminal {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiFluidPatternTerminalCraftingStatus.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiFluidPatternTerminalCraftingStatus.java
@@ -4,10 +4,6 @@ import net.minecraft.client.gui.GuiButton;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
 
-import appeng.api.storage.ITerminalHost;
-import appeng.client.gui.implementations.GuiCraftingStatus;
-import appeng.client.gui.widgets.GuiTabButton;
-
 import com.glodblock.github.common.item.ItemWirelessUltraTerminal;
 import com.glodblock.github.common.parts.PartFluidPatternTerminal;
 import com.glodblock.github.common.parts.PartFluidPatternTerminalEx;
@@ -20,6 +16,10 @@ import com.glodblock.github.inventory.item.WirelessInterfaceTerminalInventory;
 import com.glodblock.github.inventory.item.WirelessPatternTerminalInventory;
 import com.glodblock.github.loader.ItemAndBlockHolder;
 import com.glodblock.github.util.Ae2ReflectClient;
+
+import appeng.api.storage.ITerminalHost;
+import appeng.client.gui.implementations.GuiCraftingStatus;
+import appeng.client.gui.widgets.GuiTabButton;
 
 public class GuiFluidPatternTerminalCraftingStatus extends GuiCraftingStatus {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiFluidPatternTerminalEx.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiFluidPatternTerminalEx.java
@@ -5,10 +5,6 @@ import net.minecraft.util.StatCollector;
 
 import org.lwjgl.input.Mouse;
 
-import appeng.api.config.*;
-import appeng.api.storage.ITerminalHost;
-import appeng.client.gui.widgets.GuiImgButton;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.client.gui.base.FCGuiEncodeTerminal;
 import com.glodblock.github.client.gui.container.ContainerFluidPatternExWireless;
@@ -17,6 +13,10 @@ import com.glodblock.github.inventory.item.IWirelessTerminal;
 import com.glodblock.github.network.CPacketFluidPatternTermBtns;
 import com.glodblock.github.util.ModAndClassUtil;
 import com.glodblock.github.util.NameConst;
+
+import appeng.api.config.*;
+import appeng.api.storage.ITerminalHost;
+import appeng.client.gui.widgets.GuiImgButton;
 
 public class GuiFluidPatternTerminalEx extends FCGuiEncodeTerminal {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiFluidPatternWireless.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiFluidPatternWireless.java
@@ -2,10 +2,10 @@ package com.glodblock.github.client.gui;
 
 import net.minecraft.entity.player.InventoryPlayer;
 
+import com.glodblock.github.inventory.item.IWirelessTerminal;
+
 import appeng.container.slot.AppEngSlot;
 import appeng.container.slot.SlotDisabled;
-
-import com.glodblock.github.inventory.item.IWirelessTerminal;
 
 public class GuiFluidPatternWireless extends GuiFluidPatternTerminal {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiFluidPortableCell.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiFluidPortableCell.java
@@ -2,11 +2,11 @@ package com.glodblock.github.client.gui;
 
 import net.minecraft.entity.player.InventoryPlayer;
 
-import appeng.container.slot.AppEngSlot;
-
 import com.glodblock.github.client.gui.container.ContainerFluidPortableCell;
 import com.glodblock.github.inventory.item.IFluidPortableCell;
 import com.glodblock.github.inventory.item.IWirelessTerminal;
+
+import appeng.container.slot.AppEngSlot;
 
 public class GuiFluidPortableCell extends GuiFluidTerminal {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiFluidStorageBus.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiFluidStorageBus.java
@@ -6,6 +6,14 @@ import net.minecraft.entity.player.InventoryPlayer;
 
 import org.lwjgl.input.Mouse;
 
+import com.glodblock.github.FluidCraft;
+import com.glodblock.github.client.gui.container.ContainerFluidStorageBus;
+import com.glodblock.github.common.parts.PartFluidStorageBus;
+import com.glodblock.github.inventory.gui.GuiType;
+import com.glodblock.github.network.CPacketFluidPatternTermBtns;
+import com.glodblock.github.network.CPacketSwitchGuis;
+import com.glodblock.github.util.NameConst;
+
 import appeng.api.config.AccessRestriction;
 import appeng.api.config.ActionItems;
 import appeng.api.config.Settings;
@@ -17,14 +25,6 @@ import appeng.core.localization.GuiColors;
 import appeng.core.localization.GuiText;
 import appeng.core.sync.network.NetworkHandler;
 import appeng.core.sync.packets.PacketConfigButton;
-
-import com.glodblock.github.FluidCraft;
-import com.glodblock.github.client.gui.container.ContainerFluidStorageBus;
-import com.glodblock.github.common.parts.PartFluidStorageBus;
-import com.glodblock.github.inventory.gui.GuiType;
-import com.glodblock.github.network.CPacketFluidPatternTermBtns;
-import com.glodblock.github.network.CPacketSwitchGuis;
-import com.glodblock.github.util.NameConst;
 
 public class GuiFluidStorageBus extends GuiUpgradeable {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiFluidTerminal.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiFluidTerminal.java
@@ -15,13 +15,6 @@ import net.minecraftforge.fluids.FluidStack;
 
 import org.lwjgl.opengl.GL11;
 
-import appeng.api.storage.ITerminalHost;
-import appeng.api.storage.data.IAEFluidStack;
-import appeng.api.storage.data.IAEItemStack;
-import appeng.client.me.SlotME;
-import appeng.client.render.AppEngRenderItem;
-import appeng.container.slot.AppEngSlot;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.client.gui.container.ContainerFluidMonitor;
 import com.glodblock.github.common.item.ItemFluidDrop;
@@ -30,6 +23,13 @@ import com.glodblock.github.inventory.gui.GuiType;
 import com.glodblock.github.network.CPacketFluidUpdate;
 import com.glodblock.github.util.Ae2ReflectClient;
 import com.glodblock.github.util.Util;
+
+import appeng.api.storage.ITerminalHost;
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.client.me.SlotME;
+import appeng.client.render.AppEngRenderItem;
+import appeng.container.slot.AppEngSlot;
 
 public class GuiFluidTerminal extends GuiFluidMonitor {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiIngredientBuffer.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiIngredientBuffer.java
@@ -8,10 +8,6 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import org.lwjgl.opengl.GL11;
 
-import appeng.api.storage.data.IAEFluidStack;
-import appeng.client.gui.AEBaseGui;
-import appeng.core.localization.GuiText;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.client.gui.container.ContainerIngredientBuffer;
 import com.glodblock.github.common.tile.TileIngredientBuffer;
@@ -21,6 +17,10 @@ import com.glodblock.github.inventory.gui.MouseRegionManager;
 import com.glodblock.github.inventory.gui.TankMouseHandler;
 import com.glodblock.github.util.NameConst;
 import com.glodblock.github.util.RenderUtil;
+
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.client.gui.AEBaseGui;
+import appeng.core.localization.GuiText;
 
 public class GuiIngredientBuffer extends AEBaseGui {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiInterfaceTerminalWireless.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiInterfaceTerminalWireless.java
@@ -14,6 +14,17 @@ import net.minecraftforge.common.util.ForgeDirection;
 import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
 
+import com.glodblock.github.FluidCraft;
+import com.glodblock.github.client.gui.base.FCBaseMEGui;
+import com.glodblock.github.client.gui.container.ContainerInterfaceWireless;
+import com.glodblock.github.inventory.InventoryHandler;
+import com.glodblock.github.inventory.gui.GuiType;
+import com.glodblock.github.inventory.item.IWirelessTerminal;
+import com.glodblock.github.network.CPacketRenamer;
+import com.glodblock.github.util.ModAndClassUtil;
+import com.glodblock.github.util.Util;
+import com.google.common.collect.HashMultimap;
+
 import appeng.api.AEApi;
 import appeng.api.config.*;
 import appeng.api.util.WorldCoord;
@@ -32,17 +43,6 @@ import appeng.helpers.PatternHelper;
 import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.util.Platform;
-
-import com.glodblock.github.FluidCraft;
-import com.glodblock.github.client.gui.base.FCBaseMEGui;
-import com.glodblock.github.client.gui.container.ContainerInterfaceWireless;
-import com.glodblock.github.inventory.InventoryHandler;
-import com.glodblock.github.inventory.gui.GuiType;
-import com.glodblock.github.inventory.item.IWirelessTerminal;
-import com.glodblock.github.network.CPacketRenamer;
-import com.glodblock.github.util.ModAndClassUtil;
-import com.glodblock.github.util.Util;
-import com.google.common.collect.HashMultimap;
 
 public class GuiInterfaceTerminalWireless extends FCBaseMEGui implements IDropToFillTextField {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiItemMonitor.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiItemMonitor.java
@@ -5,15 +5,15 @@ import java.util.List;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
 
+import com.glodblock.github.client.gui.base.FCGuiMonitor;
+import com.glodblock.github.client.gui.container.ContainerItemMonitor;
+import com.glodblock.github.util.ModAndClassUtil;
+
 import appeng.api.storage.ITerminalHost;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.client.me.ItemRepo;
 import appeng.core.AEConfig;
 import appeng.core.localization.GuiText;
-
-import com.glodblock.github.client.gui.base.FCGuiMonitor;
-import com.glodblock.github.client.gui.container.ContainerItemMonitor;
-import com.glodblock.github.util.ModAndClassUtil;
 
 public class GuiItemMonitor extends FCGuiMonitor<IAEItemStack> {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiLargeIngredientBuffer.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiLargeIngredientBuffer.java
@@ -8,10 +8,6 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import org.lwjgl.opengl.GL11;
 
-import appeng.api.storage.data.IAEFluidStack;
-import appeng.client.gui.AEBaseGui;
-import appeng.core.localization.GuiText;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.client.gui.container.ContainerLargeIngredientBuffer;
 import com.glodblock.github.common.tile.TileLargeIngredientBuffer;
@@ -21,6 +17,10 @@ import com.glodblock.github.inventory.gui.MouseRegionManager;
 import com.glodblock.github.inventory.gui.TankMouseHandler;
 import com.glodblock.github.util.NameConst;
 import com.glodblock.github.util.RenderUtil;
+
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.client.gui.AEBaseGui;
+import appeng.core.localization.GuiText;
 
 public class GuiLargeIngredientBuffer extends AEBaseGui {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiLevelMaintainer.java
@@ -16,6 +16,16 @@ import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.input.Keyboard;
 
+import com.glodblock.github.FluidCraft;
+import com.glodblock.github.client.gui.container.ContainerLevelMaintainer;
+import com.glodblock.github.common.tile.TileLevelMaintainer;
+import com.glodblock.github.inventory.gui.MouseRegionManager;
+import com.glodblock.github.inventory.slot.SlotFluidConvertingFake;
+import com.glodblock.github.inventory.slot.SlotSingleItem;
+import com.glodblock.github.network.CPacketLevelMaintainer;
+import com.glodblock.github.util.Ae2ReflectClient;
+import com.glodblock.github.util.NameConst;
+
 import appeng.api.storage.data.IAEItemStack;
 import appeng.client.gui.AEBaseGui;
 import appeng.client.render.AppEngRenderItem;
@@ -26,16 +36,6 @@ import codechicken.nei.VisiblityData;
 import codechicken.nei.api.INEIGuiHandler;
 import codechicken.nei.api.TaggedInventoryArea;
 import cofh.core.render.CoFHFontRenderer;
-
-import com.glodblock.github.FluidCraft;
-import com.glodblock.github.client.gui.container.ContainerLevelMaintainer;
-import com.glodblock.github.common.tile.TileLevelMaintainer;
-import com.glodblock.github.inventory.gui.MouseRegionManager;
-import com.glodblock.github.inventory.slot.SlotFluidConvertingFake;
-import com.glodblock.github.inventory.slot.SlotSingleItem;
-import com.glodblock.github.network.CPacketLevelMaintainer;
-import com.glodblock.github.util.Ae2ReflectClient;
-import com.glodblock.github.util.NameConst;
 import cpw.mods.fml.common.Optional;
 
 @Optional.Interface(modid = "NotEnoughItems", iface = "codechicken.nei.api.INEIGuiHandler")

--- a/src/main/java/com/glodblock/github/client/gui/GuiOCPatternEditor.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiOCPatternEditor.java
@@ -4,13 +4,13 @@ import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.util.ResourceLocation;
 
-import appeng.client.gui.AEBaseGui;
-import appeng.core.localization.GuiText;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.client.gui.container.ContainerOCPatternEditor;
 import com.glodblock.github.common.tile.TileOCPatternEditor;
 import com.glodblock.github.util.NameConst;
+
+import appeng.client.gui.AEBaseGui;
+import appeng.core.localization.GuiText;
 
 public class GuiOCPatternEditor extends AEBaseGui {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiPatternValueAmount.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiPatternValueAmount.java
@@ -4,9 +4,6 @@ import net.minecraft.client.gui.GuiButton;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
 
-import appeng.api.storage.ITerminalHost;
-import appeng.core.localization.GuiText;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.client.gui.base.FCGuiAmount;
 import com.glodblock.github.client.gui.container.ContainerPatternValueAmount;
@@ -18,6 +15,9 @@ import com.glodblock.github.inventory.item.IWirelessTerminal;
 import com.glodblock.github.inventory.item.WirelessPatternTerminalInventory;
 import com.glodblock.github.loader.ItemAndBlockHolder;
 import com.glodblock.github.network.CPacketPatternValueSet;
+
+import appeng.api.storage.ITerminalHost;
+import appeng.core.localization.GuiText;
 
 public class GuiPatternValueAmount extends FCGuiAmount {
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiRenamer.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiRenamer.java
@@ -3,16 +3,16 @@ package com.glodblock.github.client.gui;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
 
+import com.glodblock.github.FluidCraft;
+import com.glodblock.github.client.gui.container.ContainerRenamer;
+import com.glodblock.github.network.CPacketRenamer;
+
 import appeng.api.storage.ITerminalHost;
 import appeng.client.gui.AEBaseGui;
 import appeng.client.gui.widgets.IDropToFillTextField;
 import appeng.client.gui.widgets.MEGuiTextField;
 import appeng.core.localization.GuiColors;
 import appeng.core.localization.GuiText;
-
-import com.glodblock.github.FluidCraft;
-import com.glodblock.github.client.gui.container.ContainerRenamer;
-import com.glodblock.github.network.CPacketRenamer;
 
 public class GuiRenamer extends AEBaseGui implements IDropToFillTextField {
 

--- a/src/main/java/com/glodblock/github/client/gui/base/FCBaseMEGui.java
+++ b/src/main/java/com/glodblock/github/client/gui/base/FCBaseMEGui.java
@@ -7,14 +7,14 @@ import net.minecraft.client.gui.GuiButton;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
 
-import appeng.client.gui.AEBaseMEGui;
-
 import com.glodblock.github.client.gui.*;
 import com.glodblock.github.client.gui.container.base.FCBaseContainer;
 import com.glodblock.github.common.item.ItemWirelessUltraTerminal;
 import com.glodblock.github.inventory.gui.GuiType;
 import com.glodblock.github.inventory.item.IWirelessTerminal;
 import com.glodblock.github.util.ModAndClassUtil;
+
+import appeng.client.gui.AEBaseMEGui;
 
 public abstract class FCBaseMEGui extends AEBaseMEGui {
 

--- a/src/main/java/com/glodblock/github/client/gui/base/FCGuiAmount.java
+++ b/src/main/java/com/glodblock/github/client/gui/base/FCGuiAmount.java
@@ -5,6 +5,10 @@ import net.minecraft.client.gui.GuiTextField;
 import net.minecraft.inventory.Container;
 import net.minecraft.item.ItemStack;
 
+import com.glodblock.github.FluidCraft;
+import com.glodblock.github.inventory.gui.GuiType;
+import com.glodblock.github.network.CPacketSwitchGuis;
+
 import appeng.client.gui.AEBaseGui;
 import appeng.client.gui.widgets.GuiTabButton;
 import appeng.container.AEBaseContainer;
@@ -12,10 +16,6 @@ import appeng.core.AEConfig;
 import appeng.core.localization.GuiText;
 import appeng.util.calculators.ArithHelper;
 import appeng.util.calculators.Calculator;
-
-import com.glodblock.github.FluidCraft;
-import com.glodblock.github.inventory.gui.GuiType;
-import com.glodblock.github.network.CPacketSwitchGuis;
 
 public abstract class FCGuiAmount extends AEBaseGui {
 

--- a/src/main/java/com/glodblock/github/client/gui/base/FCGuiEncodeTerminal.java
+++ b/src/main/java/com/glodblock/github/client/gui/base/FCGuiEncodeTerminal.java
@@ -6,16 +6,6 @@ import net.minecraft.inventory.Slot;
 
 import org.lwjgl.input.Keyboard;
 
-import appeng.api.storage.ITerminalHost;
-import appeng.api.storage.data.IAEItemStack;
-import appeng.client.gui.widgets.GuiImgButton;
-import appeng.client.gui.widgets.GuiScrollbar;
-import appeng.client.gui.widgets.GuiTabButton;
-import appeng.client.render.AppEngRenderItem;
-import appeng.container.slot.AppEngSlot;
-import appeng.container.slot.SlotFake;
-import appeng.util.item.AEItemStack;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.client.gui.GuiFCImgButton;
 import com.glodblock.github.client.gui.GuiItemMonitor;
@@ -27,6 +17,16 @@ import com.glodblock.github.inventory.slot.SlotSingleItem;
 import com.glodblock.github.network.CPacketFluidPatternTermBtns;
 import com.glodblock.github.util.Ae2ReflectClient;
 import com.glodblock.github.util.ModAndClassUtil;
+
+import appeng.api.storage.ITerminalHost;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.client.gui.widgets.GuiImgButton;
+import appeng.client.gui.widgets.GuiScrollbar;
+import appeng.client.gui.widgets.GuiTabButton;
+import appeng.client.render.AppEngRenderItem;
+import appeng.container.slot.AppEngSlot;
+import appeng.container.slot.SlotFake;
+import appeng.util.item.AEItemStack;
 
 public abstract class FCGuiEncodeTerminal extends GuiItemMonitor {
 

--- a/src/main/java/com/glodblock/github/client/gui/base/FCGuiMonitor.java
+++ b/src/main/java/com/glodblock/github/client/gui/base/FCGuiMonitor.java
@@ -15,6 +15,15 @@ import net.minecraft.util.ResourceLocation;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 
+import com.glodblock.github.FluidCraft;
+import com.glodblock.github.client.gui.*;
+import com.glodblock.github.client.gui.container.base.FCContainerMonitor;
+import com.glodblock.github.inventory.InventoryHandler;
+import com.glodblock.github.inventory.gui.GuiType;
+import com.glodblock.github.network.CPacketInventoryAction;
+import com.glodblock.github.util.Ae2ReflectClient;
+import com.glodblock.github.util.ModAndClassUtil;
+
 import appeng.api.config.*;
 import appeng.api.implementations.tiles.IViewCellStorage;
 import appeng.api.storage.ITerminalHost;
@@ -44,15 +53,6 @@ import appeng.util.Platform;
 import appeng.util.item.AEItemStack;
 import codechicken.nei.LayoutManager;
 import codechicken.nei.util.TextHistory;
-
-import com.glodblock.github.FluidCraft;
-import com.glodblock.github.client.gui.*;
-import com.glodblock.github.client.gui.container.base.FCContainerMonitor;
-import com.glodblock.github.inventory.InventoryHandler;
-import com.glodblock.github.inventory.gui.GuiType;
-import com.glodblock.github.network.CPacketInventoryAction;
-import com.glodblock.github.util.Ae2ReflectClient;
-import com.glodblock.github.util.ModAndClassUtil;
 
 public abstract class FCGuiMonitor<T extends IAEStack<T>> extends FCBaseMEGui
         implements ISortSource, IConfigManagerHost, IDropToFillTextField {

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerCraftingWireless.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerCraftingWireless.java
@@ -6,6 +6,9 @@ import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
 
+import com.glodblock.github.inventory.item.IWirelessCraftTerminal;
+import com.glodblock.github.inventory.item.IWirelessTerminal;
+
 import appeng.container.ContainerNull;
 import appeng.container.slot.SlotCraftingMatrix;
 import appeng.container.slot.SlotCraftingTerm;
@@ -13,9 +16,6 @@ import appeng.helpers.IContainerCraftingPacket;
 import appeng.tile.inventory.AppEngInternalInventory;
 import appeng.tile.inventory.IAEAppEngInventory;
 import appeng.tile.inventory.InvOperation;
-
-import com.glodblock.github.inventory.item.IWirelessCraftTerminal;
-import com.glodblock.github.inventory.item.IWirelessTerminal;
 
 public class ContainerCraftingWireless extends ContainerItemMonitor
         implements IAEAppEngInventory, IContainerCraftingPacket {

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerDualInterface.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerDualInterface.java
@@ -2,14 +2,14 @@ package com.glodblock.github.client.gui.container;
 
 import net.minecraft.entity.player.InventoryPlayer;
 
+import com.glodblock.github.common.tile.TileFluidInterface;
+
 import appeng.api.config.Settings;
 import appeng.api.config.SidelessMode;
 import appeng.api.util.IConfigManager;
 import appeng.container.guisync.GuiSync;
 import appeng.container.implementations.ContainerInterface;
 import appeng.helpers.IInterfaceHost;
-
-import com.glodblock.github.common.tile.TileFluidInterface;
 
 public class ContainerDualInterface extends ContainerInterface {
 

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerEssentiaMonitor.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerEssentiaMonitor.java
@@ -11,19 +11,19 @@ import net.minecraft.item.ItemStack;
 
 import org.apache.commons.lang3.tuple.MutablePair;
 
-import appeng.api.config.Actionable;
-import appeng.api.storage.data.IAEFluidStack;
-import appeng.container.slot.SlotPlayerHotBar;
-import appeng.container.slot.SlotPlayerInv;
-import appeng.util.Platform;
-import appeng.util.item.AEFluidStack;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.crossmod.thaumcraft.AspectUtil;
 import com.glodblock.github.inventory.item.IWirelessTerminal;
 import com.glodblock.github.network.CPacketFluidUpdate;
 import com.glodblock.github.network.SPacketFluidUpdate;
 import com.glodblock.github.util.Util;
+
+import appeng.api.config.Actionable;
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.container.slot.SlotPlayerHotBar;
+import appeng.container.slot.SlotPlayerInv;
+import appeng.util.Platform;
+import appeng.util.item.AEFluidStack;
 
 public class ContainerEssentiaMonitor extends ContainerFluidPortableCell {
 

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidAutoFiller.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidAutoFiller.java
@@ -6,11 +6,11 @@ import net.minecraft.item.ItemStack;
 
 import org.apache.commons.lang3.tuple.MutablePair;
 
-import appeng.container.AEBaseContainer;
-import appeng.container.slot.SlotFake;
-
 import com.glodblock.github.common.tile.TileFluidAutoFiller;
 import com.glodblock.github.util.Util;
+
+import appeng.container.AEBaseContainer;
+import appeng.container.slot.SlotFake;
 
 public class ContainerFluidAutoFiller extends AEBaseContainer {
 

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidCraftConfirm.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidCraftConfirm.java
@@ -6,10 +6,6 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.api.networking.security.IActionHost;
-import appeng.api.storage.ITerminalHost;
-import appeng.container.implementations.ContainerCraftConfirm;
-
 import com.glodblock.github.common.item.ItemBaseWirelessTerminal;
 import com.glodblock.github.common.parts.PartFluidPatternTerminal;
 import com.glodblock.github.common.parts.PartFluidPatternTerminalEx;
@@ -17,6 +13,10 @@ import com.glodblock.github.inventory.InventoryHandler;
 import com.glodblock.github.inventory.gui.GuiType;
 import com.glodblock.github.inventory.item.IWirelessTerminal;
 import com.glodblock.github.util.BlockPos;
+
+import appeng.api.networking.security.IActionHost;
+import appeng.api.storage.ITerminalHost;
+import appeng.container.implementations.ContainerCraftConfirm;
 
 public class ContainerFluidCraftConfirm extends ContainerCraftConfirm {
 

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidIO.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidIO.java
@@ -2,16 +2,16 @@ package com.glodblock.github.client.gui.container;
 
 import net.minecraft.entity.player.InventoryPlayer;
 
+import com.glodblock.github.client.gui.container.base.FCContainerFluidConfigurable;
+import com.glodblock.github.common.parts.PartFluidExportBus;
+import com.glodblock.github.common.parts.base.FCSharedFluidBus;
+import com.glodblock.github.util.Ae2Reflect;
+
 import appeng.api.config.SchedulingMode;
 import appeng.api.config.Settings;
 import appeng.api.config.YesNo;
 import appeng.api.util.IConfigManager;
 import appeng.tile.inventory.AppEngInternalAEInventory;
-
-import com.glodblock.github.client.gui.container.base.FCContainerFluidConfigurable;
-import com.glodblock.github.common.parts.PartFluidExportBus;
-import com.glodblock.github.common.parts.base.FCSharedFluidBus;
-import com.glodblock.github.util.Ae2Reflect;
 
 public class ContainerFluidIO extends FCContainerFluidConfigurable {
 

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidInterface.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidInterface.java
@@ -8,16 +8,16 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.IInventory;
 
-import appeng.api.storage.data.IAEFluidStack;
-import appeng.container.AEBaseContainer;
-import appeng.container.slot.IOptionalSlotHost;
-import appeng.util.item.AEFluidStack;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.common.item.ItemFluidPacket;
 import com.glodblock.github.inventory.IDualHost;
 import com.glodblock.github.inventory.slot.OptionalFluidSlotFakeTypeOnly;
 import com.glodblock.github.network.SPacketFluidUpdate;
+
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.container.AEBaseContainer;
+import appeng.container.slot.IOptionalSlotHost;
+import appeng.util.item.AEFluidStack;
 
 public class ContainerFluidInterface extends AEBaseContainer implements IOptionalSlotHost {
 

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidLevelEmitter.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidLevelEmitter.java
@@ -5,17 +5,16 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.IInventory;
 
-import appeng.api.config.*;
-import appeng.api.implementations.IUpgradeableHost;
-import appeng.container.guisync.GuiSync;
-import appeng.tile.inventory.AppEngInternalAEInventory;
-import appeng.util.Platform;
-
 import com.glodblock.github.client.gui.container.base.FCContainerFluidConfigurable;
 import com.glodblock.github.common.parts.PartFluidLevelEmitter;
 import com.glodblock.github.inventory.slot.OptionalFluidSlotFakeTypeOnly;
 import com.glodblock.github.util.Ae2Reflect;
 
+import appeng.api.config.*;
+import appeng.api.implementations.IUpgradeableHost;
+import appeng.container.guisync.GuiSync;
+import appeng.tile.inventory.AppEngInternalAEInventory;
+import appeng.util.Platform;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidMonitor.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidMonitor.java
@@ -15,6 +15,14 @@ import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidContainerRegistry;
 import net.minecraftforge.fluids.IFluidContainerItem;
 
+import com.glodblock.github.FluidCraft;
+import com.glodblock.github.client.gui.container.base.FCContainerMonitor;
+import com.glodblock.github.common.item.ItemFluidDrop;
+import com.glodblock.github.network.CPacketFluidUpdate;
+import com.glodblock.github.network.SPacketFluidUpdate;
+import com.glodblock.github.network.SPacketMEUpdateBuffer;
+import com.glodblock.github.util.Util;
+
 import appeng.api.AEApi;
 import appeng.api.config.Actionable;
 import appeng.api.implementations.tiles.IViewCellStorage;
@@ -36,14 +44,6 @@ import appeng.me.helpers.ChannelPowerSrc;
 import appeng.util.Platform;
 import appeng.util.item.AEFluidStack;
 import appeng.util.item.AEItemStack;
-
-import com.glodblock.github.FluidCraft;
-import com.glodblock.github.client.gui.container.base.FCContainerMonitor;
-import com.glodblock.github.common.item.ItemFluidDrop;
-import com.glodblock.github.network.CPacketFluidUpdate;
-import com.glodblock.github.network.SPacketFluidUpdate;
-import com.glodblock.github.network.SPacketMEUpdateBuffer;
-import com.glodblock.github.util.Util;
 
 public class ContainerFluidMonitor extends FCContainerMonitor<IAEFluidStack> {
 

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidPacketDecoder.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidPacketDecoder.java
@@ -4,10 +4,10 @@ import static com.glodblock.github.loader.ItemAndBlockHolder.PACKET;
 
 import net.minecraft.entity.player.InventoryPlayer;
 
-import appeng.container.AEBaseContainer;
-
 import com.glodblock.github.common.tile.TileFluidPacketDecoder;
 import com.glodblock.github.inventory.slot.FCSlotRestrictedInput;
+
+import appeng.container.AEBaseContainer;
 
 public class ContainerFluidPacketDecoder extends AEBaseContainer {
 

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidPatternEncoder.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidPatternEncoder.java
@@ -9,12 +9,6 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
-import appeng.api.AEApi;
-import appeng.api.storage.data.IAEItemStack;
-import appeng.container.AEBaseContainer;
-import appeng.container.slot.SlotRestrictedInput;
-import appeng.helpers.InventoryAction;
-
 import com.glodblock.github.common.item.ItemFluidDrop;
 import com.glodblock.github.common.item.ItemFluidEncodedPattern;
 import com.glodblock.github.common.item.ItemFluidPacket;
@@ -26,6 +20,12 @@ import com.glodblock.github.inventory.slot.SlotFluidConvertingFake;
 import com.glodblock.github.loader.ItemAndBlockHolder;
 import com.glodblock.github.util.FluidPatternDetails;
 import com.glodblock.github.util.Util;
+
+import appeng.api.AEApi;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.container.AEBaseContainer;
+import appeng.container.slot.SlotRestrictedInput;
+import appeng.helpers.InventoryAction;
 
 public class ContainerFluidPatternEncoder extends AEBaseContainer implements IPatternConsumer {
 

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidPatternTerminal.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidPatternTerminal.java
@@ -7,14 +7,14 @@ import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
 
+import com.glodblock.github.client.gui.container.base.FCContainerEncodeTerminal;
+
 import appeng.api.storage.ITerminalHost;
 import appeng.container.slot.OptionalSlotFake;
 import appeng.container.slot.SlotFakeCraftingMatrix;
 import appeng.container.slot.SlotPatternOutputs;
 import appeng.container.slot.SlotPatternTerm;
 import appeng.util.Platform;
-
-import com.glodblock.github.client.gui.container.base.FCContainerEncodeTerminal;
 
 public class ContainerFluidPatternTerminal extends FCContainerEncodeTerminal {
 

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidPatternTerminalEx.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidPatternTerminalEx.java
@@ -5,13 +5,13 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
 
+import com.glodblock.github.client.gui.container.base.FCContainerEncodeTerminal;
+
 import appeng.api.storage.ITerminalHost;
 import appeng.container.slot.IOptionalSlotHost;
 import appeng.container.slot.OptionalSlotFake;
 import appeng.helpers.InventoryAction;
 import appeng.util.Platform;
-
-import com.glodblock.github.client.gui.container.base.FCContainerEncodeTerminal;
 
 public class ContainerFluidPatternTerminalEx extends FCContainerEncodeTerminal {
 

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidStorageBus.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidStorageBus.java
@@ -5,6 +5,12 @@ import java.util.Iterator;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.IInventory;
 
+import com.glodblock.github.client.gui.container.base.FCContainerFluidConfigurable;
+import com.glodblock.github.common.item.ItemFluidPacket;
+import com.glodblock.github.common.parts.PartFluidStorageBus;
+import com.glodblock.github.inventory.slot.OptionalFluidSlotFakeTypeOnly;
+import com.glodblock.github.util.Ae2Reflect;
+
 import appeng.api.AEApi;
 import appeng.api.config.*;
 import appeng.api.storage.IMEInventory;
@@ -15,12 +21,6 @@ import appeng.container.slot.SlotRestrictedInput;
 import appeng.tile.inventory.AppEngInternalAEInventory;
 import appeng.util.Platform;
 import appeng.util.iterators.NullIterator;
-
-import com.glodblock.github.client.gui.container.base.FCContainerFluidConfigurable;
-import com.glodblock.github.common.item.ItemFluidPacket;
-import com.glodblock.github.common.parts.PartFluidStorageBus;
-import com.glodblock.github.inventory.slot.OptionalFluidSlotFakeTypeOnly;
-import com.glodblock.github.util.Ae2Reflect;
 
 public class ContainerFluidStorageBus extends FCContainerFluidConfigurable {
 

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerIngredientBuffer.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerIngredientBuffer.java
@@ -8,14 +8,14 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.IInventory;
 
-import appeng.api.storage.data.IAEFluidStack;
-import appeng.container.AEBaseContainer;
-import appeng.container.slot.SlotNormal;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.client.gui.ITankDump;
 import com.glodblock.github.common.tile.TileIngredientBuffer;
 import com.glodblock.github.network.SPacketFluidUpdate;
+
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.container.AEBaseContainer;
+import appeng.container.slot.SlotNormal;
 
 public class ContainerIngredientBuffer extends AEBaseContainer implements ITankDump {
 

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerInterfaceWireless.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerInterfaceWireless.java
@@ -10,6 +10,13 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.glodblock.github.client.gui.container.base.FCBaseContainer;
+import com.glodblock.github.common.parts.PartFluidInterface;
+import com.glodblock.github.common.tile.TileFluidInterface;
+import com.glodblock.github.inventory.item.IWirelessTerminal;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+
 import appeng.api.config.*;
 import appeng.api.networking.IGrid;
 import appeng.api.networking.IGridNode;
@@ -31,13 +38,6 @@ import appeng.util.inv.AdaptorIInventory;
 import appeng.util.inv.AdaptorPlayerHand;
 import appeng.util.inv.ItemSlot;
 import appeng.util.inv.WrapperInvSlot;
-
-import com.glodblock.github.client.gui.container.base.FCBaseContainer;
-import com.glodblock.github.common.parts.PartFluidInterface;
-import com.glodblock.github.common.tile.TileFluidInterface;
-import com.glodblock.github.inventory.item.IWirelessTerminal;
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
 
 public class ContainerInterfaceWireless extends FCBaseContainer {
 

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerItemMonitor.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerItemMonitor.java
@@ -9,6 +9,9 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.ICrafting;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.glodblock.github.client.gui.container.base.FCContainerMonitor;
+import com.glodblock.github.network.SPacketMEUpdateBuffer;
+
 import appeng.api.AEApi;
 import appeng.api.implementations.tiles.IViewCellStorage;
 import appeng.api.networking.IGrid;
@@ -25,9 +28,6 @@ import appeng.api.storage.data.IItemList;
 import appeng.container.slot.SlotRestrictedInput;
 import appeng.me.helpers.ChannelPowerSrc;
 import appeng.util.Platform;
-
-import com.glodblock.github.client.gui.container.base.FCContainerMonitor;
-import com.glodblock.github.network.SPacketMEUpdateBuffer;
 
 public class ContainerItemMonitor extends FCContainerMonitor<IAEItemStack> {
 

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerLargeIngredientBuffer.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerLargeIngredientBuffer.java
@@ -3,9 +3,9 @@ package com.glodblock.github.client.gui.container;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.IInventory;
 
-import appeng.container.slot.SlotNormal;
-
 import com.glodblock.github.common.tile.TileLargeIngredientBuffer;
+
+import appeng.container.slot.SlotNormal;
 
 public class ContainerLargeIngredientBuffer extends ContainerIngredientBuffer {
 

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerLevelMaintainer.java
@@ -5,12 +5,12 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
-import appeng.container.AEBaseContainer;
-import appeng.util.item.AEItemStack;
-
 import com.glodblock.github.common.tile.TileLevelMaintainer;
 import com.glodblock.github.inventory.AeItemStackHandler;
 import com.glodblock.github.inventory.slot.SlotFluidConvertingFake;
+
+import appeng.container.AEBaseContainer;
+import appeng.util.item.AEItemStack;
 
 public class ContainerLevelMaintainer extends AEBaseContainer {
 

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerOCPatternEditor.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerOCPatternEditor.java
@@ -2,10 +2,10 @@ package com.glodblock.github.client.gui.container;
 
 import net.minecraft.entity.player.InventoryPlayer;
 
+import com.glodblock.github.common.tile.TileOCPatternEditor;
+
 import appeng.container.AEBaseContainer;
 import appeng.container.slot.SlotRestrictedInput;
-
-import com.glodblock.github.common.tile.TileOCPatternEditor;
 
 public class ContainerOCPatternEditor extends AEBaseContainer {
 

--- a/src/main/java/com/glodblock/github/client/gui/container/base/FCBaseContainer.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/base/FCBaseContainer.java
@@ -2,11 +2,11 @@ package com.glodblock.github.client.gui.container.base;
 
 import net.minecraft.entity.player.InventoryPlayer;
 
-import appeng.api.storage.ITerminalHost;
-import appeng.container.AEBaseContainer;
-
 import com.glodblock.github.inventory.item.IFluidPortableCell;
 import com.glodblock.github.util.Util;
+
+import appeng.api.storage.ITerminalHost;
+import appeng.container.AEBaseContainer;
 
 public abstract class FCBaseContainer extends AEBaseContainer {
 

--- a/src/main/java/com/glodblock/github/client/gui/container/base/FCContainerEncodeTerminal.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/base/FCContainerEncodeTerminal.java
@@ -17,6 +17,16 @@ import net.minecraftforge.fluids.FluidContainerRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.IFluidContainerItem;
 
+import com.glodblock.github.client.gui.container.ContainerItemMonitor;
+import com.glodblock.github.common.item.ItemFluidDrop;
+import com.glodblock.github.common.item.ItemFluidEncodedPattern;
+import com.glodblock.github.common.item.ItemFluidPacket;
+import com.glodblock.github.inventory.IPatternConsumer;
+import com.glodblock.github.inventory.item.IItemPatternTerminal;
+import com.glodblock.github.loader.ItemAndBlockHolder;
+import com.glodblock.github.util.FluidPatternDetails;
+import com.glodblock.github.util.Util;
+
 import appeng.api.AEApi;
 import appeng.api.config.Actionable;
 import appeng.api.definitions.IDefinitions;
@@ -32,16 +42,6 @@ import appeng.tile.inventory.IAEAppEngInventory;
 import appeng.tile.inventory.InvOperation;
 import appeng.util.Platform;
 import appeng.util.item.AEItemStack;
-
-import com.glodblock.github.client.gui.container.ContainerItemMonitor;
-import com.glodblock.github.common.item.ItemFluidDrop;
-import com.glodblock.github.common.item.ItemFluidEncodedPattern;
-import com.glodblock.github.common.item.ItemFluidPacket;
-import com.glodblock.github.inventory.IPatternConsumer;
-import com.glodblock.github.inventory.item.IItemPatternTerminal;
-import com.glodblock.github.loader.ItemAndBlockHolder;
-import com.glodblock.github.util.FluidPatternDetails;
-import com.glodblock.github.util.Util;
 
 public abstract class FCContainerEncodeTerminal extends ContainerItemMonitor
         implements IAEAppEngInventory, IOptionalSlotHost, IContainerCraftingPacket, IPatternConsumer {

--- a/src/main/java/com/glodblock/github/client/gui/container/base/FCContainerFluidConfigurable.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/base/FCContainerFluidConfigurable.java
@@ -10,6 +10,13 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
+import com.glodblock.github.FluidCraft;
+import com.glodblock.github.common.item.ItemFluidPacket;
+import com.glodblock.github.inventory.slot.OptionalFluidSlotFakeTypeOnly;
+import com.glodblock.github.network.SPacketFluidUpdate;
+import com.glodblock.github.util.Ae2Reflect;
+import com.glodblock.github.util.Util;
+
 import appeng.api.config.Upgrades;
 import appeng.api.implementations.IUpgradeableHost;
 import appeng.api.storage.data.IAEFluidStack;
@@ -18,13 +25,6 @@ import appeng.container.slot.AppEngSlot;
 import appeng.tile.inventory.AppEngInternalAEInventory;
 import appeng.util.Platform;
 import appeng.util.item.AEFluidStack;
-
-import com.glodblock.github.FluidCraft;
-import com.glodblock.github.common.item.ItemFluidPacket;
-import com.glodblock.github.inventory.slot.OptionalFluidSlotFakeTypeOnly;
-import com.glodblock.github.network.SPacketFluidUpdate;
-import com.glodblock.github.util.Ae2Reflect;
-import com.glodblock.github.util.Util;
 
 public abstract class FCContainerFluidConfigurable extends ContainerUpgradeable {
 

--- a/src/main/java/com/glodblock/github/client/gui/container/base/FCContainerMonitor.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/base/FCContainerMonitor.java
@@ -10,6 +10,9 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.ICrafting;
 import net.minecraft.item.ItemStack;
 
+import com.glodblock.github.inventory.item.IWirelessTerminal;
+import com.glodblock.github.network.SPacketMEUpdateBuffer;
+
 import appeng.api.config.*;
 import appeng.api.networking.IGridNode;
 import appeng.api.networking.energy.IEnergyGrid;
@@ -28,9 +31,6 @@ import appeng.helpers.WirelessTerminalGuiObject;
 import appeng.util.ConfigManager;
 import appeng.util.IConfigManagerHost;
 import appeng.util.Platform;
-
-import com.glodblock.github.inventory.item.IWirelessTerminal;
-import com.glodblock.github.network.SPacketMEUpdateBuffer;
 
 public abstract class FCContainerMonitor<T extends IAEStack<T>> extends FCBaseContainer
         implements IConfigManagerHost, IConfigurableObject, IMEMonitorHandlerReceiver<T> {

--- a/src/main/java/com/glodblock/github/client/me/EssentiaRepo.java
+++ b/src/main/java/com/glodblock/github/client/me/EssentiaRepo.java
@@ -5,13 +5,13 @@ import java.util.Iterator;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
+import com.glodblock.github.common.item.ItemFluidDrop;
+import com.glodblock.github.crossmod.thaumcraft.AspectUtil;
+
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.client.gui.widgets.IScrollSource;
 import appeng.client.gui.widgets.ISortSource;
-
-import com.glodblock.github.common.item.ItemFluidDrop;
-import com.glodblock.github.crossmod.thaumcraft.AspectUtil;
 
 public class EssentiaRepo extends FluidRepo {
 

--- a/src/main/java/com/glodblock/github/client/me/FluidRepo.java
+++ b/src/main/java/com/glodblock/github/client/me/FluidRepo.java
@@ -20,6 +20,10 @@ import javax.annotation.Nonnull;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
 
+import com.glodblock.github.common.item.ItemFluidDrop;
+import com.glodblock.github.util.FluidSorters;
+import com.glodblock.github.util.Util;
+
 import appeng.api.AEApi;
 import appeng.api.config.*;
 import appeng.api.storage.data.IAEItemStack;
@@ -30,10 +34,6 @@ import appeng.client.me.ItemRepo;
 import appeng.core.AEConfig;
 import appeng.items.storage.ItemViewCell;
 import appeng.util.prioitylist.IPartitionList;
-
-import com.glodblock.github.common.item.ItemFluidDrop;
-import com.glodblock.github.util.FluidSorters;
-import com.glodblock.github.util.Util;
 import cpw.mods.fml.relauncher.ReflectionHelper;
 
 public class FluidRepo extends ItemRepo {

--- a/src/main/java/com/glodblock/github/client/render/ItemCertusQuartzTankRender.java
+++ b/src/main/java/com/glodblock/github/client/render/ItemCertusQuartzTankRender.java
@@ -19,6 +19,7 @@ import com.glodblock.github.FluidCraft;
 import com.glodblock.github.client.render.tank.ModelCertusTank;
 import com.glodblock.github.common.tile.TileCertusQuartzTank;
 import com.glodblock.github.loader.ItemAndBlockHolder;
+
 import cpw.mods.fml.client.registry.ClientRegistry;
 
 public class ItemCertusQuartzTankRender implements IItemRenderer {

--- a/src/main/java/com/glodblock/github/client/render/ItemWalrusRender.java
+++ b/src/main/java/com/glodblock/github/client/render/ItemWalrusRender.java
@@ -14,6 +14,7 @@ import org.lwjgl.opengl.GL11;
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.common.tile.TileWalrus;
 import com.glodblock.github.loader.ItemAndBlockHolder;
+
 import cpw.mods.fml.client.registry.ClientRegistry;
 
 public class ItemWalrusRender implements IItemRenderer {

--- a/src/main/java/com/glodblock/github/client/render/RenderBlockFluidBuffer.java
+++ b/src/main/java/com/glodblock/github/client/render/RenderBlockFluidBuffer.java
@@ -10,11 +10,11 @@ import net.minecraftforge.fluids.FluidRegistry;
 
 import org.lwjgl.opengl.GL11;
 
-import appeng.client.render.BaseBlockRender;
-import appeng.client.render.BlockRenderInfo;
-
 import com.glodblock.github.common.block.BlockFluidBuffer;
 import com.glodblock.github.common.tile.TileFluidBuffer;
+
+import appeng.client.render.BaseBlockRender;
+import appeng.client.render.BlockRenderInfo;
 
 public class RenderBlockFluidBuffer extends BaseBlockRender<BlockFluidBuffer, TileFluidBuffer> {
 

--- a/src/main/java/com/glodblock/github/client/render/RenderBlockFluidInterface.java
+++ b/src/main/java/com/glodblock/github/client/render/RenderBlockFluidInterface.java
@@ -5,13 +5,13 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.client.render.BaseBlockRender;
-import appeng.client.render.BlockRenderInfo;
-import appeng.tile.misc.TileInterface;
-
 import com.glodblock.github.client.textures.FCPartsTexture;
 import com.glodblock.github.common.block.BlockFluidInterface;
 import com.glodblock.github.common.tile.TileFluidInterface;
+
+import appeng.client.render.BaseBlockRender;
+import appeng.client.render.BlockRenderInfo;
+import appeng.tile.misc.TileInterface;
 
 public class RenderBlockFluidInterface extends BaseBlockRender<BlockFluidInterface, TileFluidInterface> {
 

--- a/src/main/java/com/glodblock/github/client/render/RenderBlockLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/client/render/RenderBlockLevelMaintainer.java
@@ -4,12 +4,12 @@ import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 
-import appeng.client.render.BaseBlockRender;
-import appeng.client.render.BlockRenderInfo;
-
 import com.glodblock.github.client.textures.FCPartsTexture;
 import com.glodblock.github.common.block.BlockLevelMaintainer;
 import com.glodblock.github.common.tile.TileLevelMaintainer;
+
+import appeng.client.render.BaseBlockRender;
+import appeng.client.render.BlockRenderInfo;
 
 public class RenderBlockLevelMaintainer extends BaseBlockRender<BlockLevelMaintainer, TileLevelMaintainer> {
 

--- a/src/main/java/com/glodblock/github/common/block/BlockCertusQuartzTank.java
+++ b/src/main/java/com/glodblock/github/common/block/BlockCertusQuartzTank.java
@@ -17,8 +17,6 @@ import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidContainerRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
-import appeng.api.implementations.items.IAEWrench;
-
 import com.glodblock.github.common.item.ItemCertusQuartzTank;
 import com.glodblock.github.common.tabs.FluidCraftingTabs;
 import com.glodblock.github.common.tile.TileCertusQuartzTank;
@@ -27,6 +25,7 @@ import com.glodblock.github.loader.IRegister;
 import com.glodblock.github.loader.ItemAndBlockHolder;
 import com.glodblock.github.util.NameConst;
 
+import appeng.api.implementations.items.IAEWrench;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;

--- a/src/main/java/com/glodblock/github/common/block/BlockFluidAutoFiller.java
+++ b/src/main/java/com/glodblock/github/common/block/BlockFluidAutoFiller.java
@@ -12,9 +12,6 @@ import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.api.config.SecurityPermissions;
-import appeng.util.Platform;
-
 import com.glodblock.github.common.item.FCBaseItemBlock;
 import com.glodblock.github.common.tabs.FluidCraftingTabs;
 import com.glodblock.github.common.tile.TileFluidAutoFiller;
@@ -25,6 +22,8 @@ import com.glodblock.github.util.NameConst;
 import com.glodblock.github.util.RenderUtil;
 import com.glodblock.github.util.Util;
 
+import appeng.api.config.SecurityPermissions;
+import appeng.util.Platform;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;

--- a/src/main/java/com/glodblock/github/common/block/BlockFluidBuffer.java
+++ b/src/main/java/com/glodblock/github/common/block/BlockFluidBuffer.java
@@ -11,9 +11,6 @@ import net.minecraft.util.ChatComponentText;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidStack;
 
-import appeng.api.storage.data.IAEFluidStack;
-import appeng.util.Platform;
-
 import com.glodblock.github.client.render.RenderBlockFluidBuffer;
 import com.glodblock.github.common.item.FCBaseItemBlock;
 import com.glodblock.github.common.tabs.FluidCraftingTabs;
@@ -22,6 +19,8 @@ import com.glodblock.github.crossmod.waila.Tooltip;
 import com.glodblock.github.util.NameConst;
 import com.glodblock.github.util.Util;
 
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.util.Platform;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;

--- a/src/main/java/com/glodblock/github/common/block/BlockFluidInterface.java
+++ b/src/main/java/com/glodblock/github/common/block/BlockFluidInterface.java
@@ -7,12 +7,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.api.util.IOrientable;
-import appeng.block.AEBaseItemBlock;
-import appeng.core.features.AEFeature;
-import appeng.tile.misc.TileInterface;
-import appeng.util.Platform;
-
 import com.glodblock.github.client.render.RenderBlockFluidInterface;
 import com.glodblock.github.common.tabs.FluidCraftingTabs;
 import com.glodblock.github.common.tile.TileFluidInterface;
@@ -21,6 +15,11 @@ import com.glodblock.github.inventory.gui.GuiType;
 import com.glodblock.github.util.BlockPos;
 import com.glodblock.github.util.NameConst;
 
+import appeng.api.util.IOrientable;
+import appeng.block.AEBaseItemBlock;
+import appeng.core.features.AEFeature;
+import appeng.tile.misc.TileInterface;
+import appeng.util.Platform;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;

--- a/src/main/java/com/glodblock/github/common/block/BlockFluidPatternEncoder.java
+++ b/src/main/java/com/glodblock/github/common/block/BlockFluidPatternEncoder.java
@@ -5,14 +5,14 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.block.AEBaseItemBlock;
-
 import com.glodblock.github.common.tabs.FluidCraftingTabs;
 import com.glodblock.github.common.tile.TileFluidPatternEncoder;
 import com.glodblock.github.inventory.InventoryHandler;
 import com.glodblock.github.inventory.gui.GuiType;
 import com.glodblock.github.util.BlockPos;
 import com.glodblock.github.util.NameConst;
+
+import appeng.block.AEBaseItemBlock;
 import cpw.mods.fml.common.registry.GameRegistry;
 
 public class BlockFluidPatternEncoder extends FCBaseBlock {

--- a/src/main/java/com/glodblock/github/common/block/BlockIngredientBuffer.java
+++ b/src/main/java/com/glodblock/github/common/block/BlockIngredientBuffer.java
@@ -5,14 +5,14 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.block.AEBaseItemBlock;
-
 import com.glodblock.github.common.tabs.FluidCraftingTabs;
 import com.glodblock.github.common.tile.TileIngredientBuffer;
 import com.glodblock.github.inventory.InventoryHandler;
 import com.glodblock.github.inventory.gui.GuiType;
 import com.glodblock.github.util.BlockPos;
 import com.glodblock.github.util.NameConst;
+
+import appeng.block.AEBaseItemBlock;
 import cpw.mods.fml.common.registry.GameRegistry;
 
 public class BlockIngredientBuffer extends FCBaseBlock {

--- a/src/main/java/com/glodblock/github/common/block/BlockLargeIngredientBuffer.java
+++ b/src/main/java/com/glodblock/github/common/block/BlockLargeIngredientBuffer.java
@@ -5,14 +5,14 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.block.AEBaseItemBlock;
-
 import com.glodblock.github.common.tabs.FluidCraftingTabs;
 import com.glodblock.github.common.tile.TileLargeIngredientBuffer;
 import com.glodblock.github.inventory.InventoryHandler;
 import com.glodblock.github.inventory.gui.GuiType;
 import com.glodblock.github.util.BlockPos;
 import com.glodblock.github.util.NameConst;
+
+import appeng.block.AEBaseItemBlock;
 import cpw.mods.fml.common.registry.GameRegistry;
 
 public class BlockLargeIngredientBuffer extends FCBaseBlock {

--- a/src/main/java/com/glodblock/github/common/block/BlockLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/common/block/BlockLevelMaintainer.java
@@ -12,9 +12,6 @@ import net.minecraft.util.ChatComponentText;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.api.config.SecurityPermissions;
-import appeng.util.Platform;
-
 import com.glodblock.github.client.render.RenderBlockLevelMaintainer;
 import com.glodblock.github.common.item.FCBaseItemBlock;
 import com.glodblock.github.common.tabs.FluidCraftingTabs;
@@ -26,6 +23,8 @@ import com.glodblock.github.util.NameConst;
 import com.glodblock.github.util.RenderUtil;
 import com.glodblock.github.util.Util;
 
+import appeng.api.config.SecurityPermissions;
+import appeng.util.Platform;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;

--- a/src/main/java/com/glodblock/github/common/block/BlockOCPatternEditor.java
+++ b/src/main/java/com/glodblock/github/common/block/BlockOCPatternEditor.java
@@ -5,8 +5,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.block.AEBaseItemBlock;
-
 import com.glodblock.github.common.tabs.FluidCraftingTabs;
 import com.glodblock.github.common.tile.TileOCPatternEditor;
 import com.glodblock.github.inventory.InventoryHandler;
@@ -14,6 +12,8 @@ import com.glodblock.github.inventory.gui.GuiType;
 import com.glodblock.github.util.BlockPos;
 import com.glodblock.github.util.ModAndClassUtil;
 import com.glodblock.github.util.NameConst;
+
+import appeng.block.AEBaseItemBlock;
 import cpw.mods.fml.common.registry.GameRegistry;
 
 public class BlockOCPatternEditor extends FCBaseBlock {

--- a/src/main/java/com/glodblock/github/common/block/FCBaseBlock.java
+++ b/src/main/java/com/glodblock/github/common/block/FCBaseBlock.java
@@ -8,15 +8,14 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 
+import com.glodblock.github.FluidCraft;
+import com.glodblock.github.loader.IRegister;
+
 import appeng.block.AEBaseTileBlock;
 import appeng.core.features.AEFeature;
 import appeng.core.features.ActivityState;
 import appeng.core.features.BlockStackSrc;
 import appeng.tile.AEBaseTile;
-
-import com.glodblock.github.FluidCraft;
-import com.glodblock.github.loader.IRegister;
-
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 

--- a/src/main/java/com/glodblock/github/common/item/FCBaseItemBlock.java
+++ b/src/main/java/com/glodblock/github/common/item/FCBaseItemBlock.java
@@ -6,10 +6,9 @@ import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 
-import appeng.block.AEBaseItemBlock;
-
 import com.glodblock.github.common.block.FCBaseBlock;
 
+import appeng.block.AEBaseItemBlock;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 

--- a/src/main/java/com/glodblock/github/common/item/FCBaseItemCell.java
+++ b/src/main/java/com/glodblock/github/common/item/FCBaseItemCell.java
@@ -14,6 +14,16 @@ import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.glodblock.github.common.Config;
+import com.glodblock.github.common.storage.CellType;
+import com.glodblock.github.common.storage.IFluidCellInventory;
+import com.glodblock.github.common.storage.IFluidCellInventoryHandler;
+import com.glodblock.github.common.storage.IStorageFluidCell;
+import com.glodblock.github.loader.ItemAndBlockHolder;
+import com.glodblock.github.util.ModAndClassUtil;
+import com.glodblock.github.util.NameConst;
+import com.google.common.base.Optional;
+
 import appeng.api.AEApi;
 import appeng.api.config.FuzzyMode;
 import appeng.api.config.IncludeExclude;
@@ -30,16 +40,6 @@ import appeng.items.contents.CellUpgrades;
 import appeng.util.InventoryAdaptor;
 import appeng.util.Platform;
 import appeng.util.ReadableNumberConverter;
-
-import com.glodblock.github.common.Config;
-import com.glodblock.github.common.storage.CellType;
-import com.glodblock.github.common.storage.IFluidCellInventory;
-import com.glodblock.github.common.storage.IFluidCellInventoryHandler;
-import com.glodblock.github.common.storage.IStorageFluidCell;
-import com.glodblock.github.loader.ItemAndBlockHolder;
-import com.glodblock.github.util.ModAndClassUtil;
-import com.glodblock.github.util.NameConst;
-import com.google.common.base.Optional;
 
 public abstract class FCBaseItemCell extends AEBaseItem implements IStorageFluidCell {
 

--- a/src/main/java/com/glodblock/github/common/item/ItemBaseWirelessTerminal.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemBaseWirelessTerminal.java
@@ -13,6 +13,12 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.event.ForgeEventFactory;
 
+import com.glodblock.github.inventory.InventoryHandler;
+import com.glodblock.github.inventory.gui.GuiType;
+import com.glodblock.github.inventory.item.IItemInventory;
+import com.glodblock.github.util.BlockPos;
+import com.glodblock.github.util.NameConst;
+
 import appeng.api.AEApi;
 import appeng.api.features.ILocatable;
 import appeng.api.features.IWirelessTermHandler;
@@ -20,13 +26,6 @@ import appeng.api.features.IWirelessTermRegistry;
 import appeng.core.localization.PlayerMessages;
 import appeng.items.tools.powered.ToolWirelessTerminal;
 import appeng.util.Platform;
-
-import com.glodblock.github.inventory.InventoryHandler;
-import com.glodblock.github.inventory.gui.GuiType;
-import com.glodblock.github.inventory.item.IItemInventory;
-import com.glodblock.github.util.BlockPos;
-import com.glodblock.github.util.NameConst;
-
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 

--- a/src/main/java/com/glodblock/github/common/item/ItemBasicFluidStorageCell.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemBasicFluidStorageCell.java
@@ -12,10 +12,6 @@ import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.event.ForgeEventFactory;
 
-import appeng.api.exceptions.MissingDefinition;
-import appeng.core.AEConfig;
-import appeng.core.features.AEFeature;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.common.Config;
 import com.glodblock.github.common.storage.CellType;
@@ -26,6 +22,9 @@ import com.glodblock.github.loader.ItemAndBlockHolder;
 import com.glodblock.github.util.NameConst;
 import com.google.common.base.Optional;
 
+import appeng.api.exceptions.MissingDefinition;
+import appeng.core.AEConfig;
+import appeng.core.features.AEFeature;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;

--- a/src/main/java/com/glodblock/github/common/item/ItemCreativeFluidStorageCell.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemCreativeFluidStorageCell.java
@@ -9,6 +9,16 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
 
+import com.glodblock.github.FluidCraft;
+import com.glodblock.github.common.Config;
+import com.glodblock.github.common.storage.IFluidCellInventory;
+import com.glodblock.github.common.storage.IFluidCellInventoryHandler;
+import com.glodblock.github.common.storage.IStorageFluidCell;
+import com.glodblock.github.common.tabs.FluidCraftingTabs;
+import com.glodblock.github.loader.IRegister;
+import com.glodblock.github.util.ModAndClassUtil;
+import com.glodblock.github.util.NameConst;
+
 import appeng.api.AEApi;
 import appeng.api.config.FuzzyMode;
 import appeng.api.storage.IMEInventoryHandler;
@@ -19,16 +29,6 @@ import appeng.items.AEBaseItem;
 import appeng.items.contents.CellConfig;
 import appeng.items.contents.CellUpgrades;
 import appeng.util.Platform;
-
-import com.glodblock.github.FluidCraft;
-import com.glodblock.github.common.Config;
-import com.glodblock.github.common.storage.IFluidCellInventory;
-import com.glodblock.github.common.storage.IFluidCellInventoryHandler;
-import com.glodblock.github.common.storage.IStorageFluidCell;
-import com.glodblock.github.common.tabs.FluidCraftingTabs;
-import com.glodblock.github.loader.IRegister;
-import com.glodblock.github.util.ModAndClassUtil;
-import com.glodblock.github.util.NameConst;
 import cpw.mods.fml.common.registry.GameRegistry;
 
 public class ItemCreativeFluidStorageCell extends AEBaseItem

--- a/src/main/java/com/glodblock/github/common/item/ItemFluidConversionMonitor.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemFluidConversionMonitor.java
@@ -5,14 +5,13 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
-import appeng.api.AEApi;
-import appeng.api.parts.IPartItem;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.common.parts.PartFluidConversionMonitor;
 import com.glodblock.github.common.tabs.FluidCraftingTabs;
 import com.glodblock.github.util.NameConst;
 
+import appeng.api.AEApi;
+import appeng.api.parts.IPartItem;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;

--- a/src/main/java/com/glodblock/github/common/item/ItemFluidDrop.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemFluidDrop.java
@@ -19,15 +19,14 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
-import appeng.api.storage.data.IAEFluidStack;
-import appeng.api.storage.data.IAEItemStack;
-import appeng.util.item.AEFluidStack;
-import appeng.util.item.AEItemStack;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.loader.ItemAndBlockHolder;
 import com.glodblock.github.util.NameConst;
 
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.util.item.AEFluidStack;
+import appeng.util.item.AEItemStack;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;

--- a/src/main/java/com/glodblock/github/common/item/ItemFluidEncodedPattern.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemFluidEncodedPattern.java
@@ -3,13 +3,13 @@ package com.glodblock.github.common.item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
-import appeng.api.networking.crafting.ICraftingPatternDetails;
-import appeng.items.misc.ItemEncodedPattern;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.loader.IRegister;
 import com.glodblock.github.util.FluidPatternDetails;
 import com.glodblock.github.util.NameConst;
+
+import appeng.api.networking.crafting.ICraftingPatternDetails;
+import appeng.items.misc.ItemEncodedPattern;
 import cpw.mods.fml.common.registry.GameRegistry;
 
 public class ItemFluidEncodedPattern extends ItemEncodedPattern implements IRegister<ItemFluidEncodedPattern> {

--- a/src/main/java/com/glodblock/github/common/item/ItemFluidExportBus.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemFluidExportBus.java
@@ -7,15 +7,14 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
-import appeng.api.AEApi;
-import appeng.api.parts.IPartItem;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.common.Config;
 import com.glodblock.github.common.parts.PartFluidExportBus;
 import com.glodblock.github.common.tabs.FluidCraftingTabs;
 import com.glodblock.github.util.NameConst;
 
+import appeng.api.AEApi;
+import appeng.api.parts.IPartItem;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;

--- a/src/main/java/com/glodblock/github/common/item/ItemFluidExtremeStorageCell.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemFluidExtremeStorageCell.java
@@ -9,6 +9,7 @@ import com.glodblock.github.common.Config;
 import com.glodblock.github.common.storage.IStorageFluidCell;
 import com.glodblock.github.common.tabs.FluidCraftingTabs;
 import com.glodblock.github.loader.IRegister;
+
 import cpw.mods.fml.common.registry.GameRegistry;
 
 public class ItemFluidExtremeStorageCell extends FCBaseItemCell

--- a/src/main/java/com/glodblock/github/common/item/ItemFluidImportBus.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemFluidImportBus.java
@@ -7,15 +7,14 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
-import appeng.api.AEApi;
-import appeng.api.parts.IPartItem;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.common.Config;
 import com.glodblock.github.common.parts.PartFluidImportBus;
 import com.glodblock.github.common.tabs.FluidCraftingTabs;
 import com.glodblock.github.util.NameConst;
 
+import appeng.api.AEApi;
+import appeng.api.parts.IPartItem;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;

--- a/src/main/java/com/glodblock/github/common/item/ItemFluidLevelEmitter.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemFluidLevelEmitter.java
@@ -7,16 +7,15 @@ import net.minecraft.world.World;
 
 import org.jetbrains.annotations.Nullable;
 
-import appeng.api.AEApi;
-import appeng.api.parts.IPart;
-import appeng.api.parts.IPartItem;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.client.textures.FCPartsTexture;
 import com.glodblock.github.common.parts.PartFluidLevelEmitter;
 import com.glodblock.github.common.tabs.FluidCraftingTabs;
 import com.glodblock.github.util.NameConst;
 
+import appeng.api.AEApi;
+import appeng.api.parts.IPart;
+import appeng.api.parts.IPartItem;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;

--- a/src/main/java/com/glodblock/github/common/item/ItemFluidPacket.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemFluidPacket.java
@@ -16,14 +16,13 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
-import appeng.api.storage.data.IAEFluidStack;
-import appeng.api.storage.data.IAEItemStack;
-import appeng.util.item.AEItemStack;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.loader.ItemAndBlockHolder;
 import com.glodblock.github.util.NameConst;
 
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.util.item.AEItemStack;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;

--- a/src/main/java/com/glodblock/github/common/item/ItemFluidStorageMonitor.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemFluidStorageMonitor.java
@@ -5,14 +5,13 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
-import appeng.api.AEApi;
-import appeng.api.parts.IPartItem;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.common.parts.PartFluidStorageMonitor;
 import com.glodblock.github.common.tabs.FluidCraftingTabs;
 import com.glodblock.github.util.NameConst;
 
+import appeng.api.AEApi;
+import appeng.api.parts.IPartItem;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;

--- a/src/main/java/com/glodblock/github/common/item/ItemMultiFluidStorageCell.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemMultiFluidStorageCell.java
@@ -12,10 +12,6 @@ import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.event.ForgeEventFactory;
 
-import appeng.api.exceptions.MissingDefinition;
-import appeng.core.AEConfig;
-import appeng.core.features.AEFeature;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.common.Config;
 import com.glodblock.github.common.storage.CellType;
@@ -26,6 +22,9 @@ import com.glodblock.github.loader.ItemAndBlockHolder;
 import com.glodblock.github.util.NameConst;
 import com.google.common.base.Optional;
 
+import appeng.api.exceptions.MissingDefinition;
+import appeng.core.AEConfig;
+import appeng.core.features.AEFeature;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;

--- a/src/main/java/com/glodblock/github/common/item/ItemPartFluidInterface.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemPartFluidInterface.java
@@ -7,14 +7,13 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
-import appeng.api.AEApi;
-import appeng.api.parts.IPartItem;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.common.parts.PartFluidInterface;
 import com.glodblock.github.common.tabs.FluidCraftingTabs;
 import com.glodblock.github.util.NameConst;
 
+import appeng.api.AEApi;
+import appeng.api.parts.IPartItem;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;

--- a/src/main/java/com/glodblock/github/common/item/ItemPartFluidPatternTerminal.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemPartFluidPatternTerminal.java
@@ -7,14 +7,13 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
-import appeng.api.AEApi;
-import appeng.api.parts.IPartItem;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.common.parts.PartFluidPatternTerminal;
 import com.glodblock.github.common.tabs.FluidCraftingTabs;
 import com.glodblock.github.util.NameConst;
 
+import appeng.api.AEApi;
+import appeng.api.parts.IPartItem;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;

--- a/src/main/java/com/glodblock/github/common/item/ItemPartFluidPatternTerminalEx.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemPartFluidPatternTerminalEx.java
@@ -7,14 +7,13 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
-import appeng.api.AEApi;
-import appeng.api.parts.IPartItem;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.common.parts.PartFluidPatternTerminalEx;
 import com.glodblock.github.common.tabs.FluidCraftingTabs;
 import com.glodblock.github.util.NameConst;
 
+import appeng.api.AEApi;
+import appeng.api.parts.IPartItem;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;

--- a/src/main/java/com/glodblock/github/common/item/ItemPartFluidStorageBus.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemPartFluidStorageBus.java
@@ -7,14 +7,13 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
-import appeng.api.AEApi;
-import appeng.api.parts.IPartItem;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.common.parts.PartFluidStorageBus;
 import com.glodblock.github.common.tabs.FluidCraftingTabs;
 import com.glodblock.github.util.NameConst;
 
+import appeng.api.AEApi;
+import appeng.api.parts.IPartItem;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;

--- a/src/main/java/com/glodblock/github/common/item/ItemPartFluidTerminal.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemPartFluidTerminal.java
@@ -11,14 +11,13 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
-import appeng.api.AEApi;
-import appeng.api.parts.IPartItem;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.common.parts.PartFluidTerminal;
 import com.glodblock.github.common.tabs.FluidCraftingTabs;
 import com.glodblock.github.util.NameConst;
 
+import appeng.api.AEApi;
+import appeng.api.parts.IPartItem;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;

--- a/src/main/java/com/glodblock/github/common/item/ItemPortableFluidCell.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemPortableFluidCell.java
@@ -12,18 +12,6 @@ import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.api.AEApi;
-import appeng.api.config.FuzzyMode;
-import appeng.api.storage.IMEInventoryHandler;
-import appeng.api.storage.StorageChannel;
-import appeng.api.storage.data.IAEFluidStack;
-import appeng.core.features.AEFeature;
-import appeng.core.localization.GuiText;
-import appeng.items.contents.CellConfig;
-import appeng.items.contents.CellUpgrades;
-import appeng.items.tools.powered.powersink.AEBasePoweredItem;
-import appeng.util.Platform;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.common.Config;
 import com.glodblock.github.common.storage.IFluidCellInventory;
@@ -41,6 +29,17 @@ import com.glodblock.github.util.NameConst;
 import com.glodblock.github.util.RenderUtil;
 import com.google.common.base.Optional;
 
+import appeng.api.AEApi;
+import appeng.api.config.FuzzyMode;
+import appeng.api.storage.IMEInventoryHandler;
+import appeng.api.storage.StorageChannel;
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.core.features.AEFeature;
+import appeng.core.localization.GuiText;
+import appeng.items.contents.CellConfig;
+import appeng.items.contents.CellUpgrades;
+import appeng.items.tools.powered.powersink.AEBasePoweredItem;
+import appeng.util.Platform;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;

--- a/src/main/java/com/glodblock/github/common/item/ItemWirelessFluidTerminal.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemWirelessFluidTerminal.java
@@ -6,11 +6,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
-import appeng.api.AEApi;
-import appeng.api.networking.IGridNode;
-import appeng.core.features.AEFeature;
-import appeng.core.localization.PlayerMessages;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.common.tabs.FluidCraftingTabs;
 import com.glodblock.github.inventory.gui.GuiType;
@@ -18,6 +13,11 @@ import com.glodblock.github.inventory.item.WirelessFluidTerminalInventory;
 import com.glodblock.github.loader.IRegister;
 import com.glodblock.github.util.NameConst;
 import com.glodblock.github.util.Util;
+
+import appeng.api.AEApi;
+import appeng.api.networking.IGridNode;
+import appeng.core.features.AEFeature;
+import appeng.core.localization.PlayerMessages;
 import cpw.mods.fml.common.registry.GameRegistry;
 
 public class ItemWirelessFluidTerminal extends ItemBaseWirelessTerminal

--- a/src/main/java/com/glodblock/github/common/item/ItemWirelessInterfaceTerminal.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemWirelessInterfaceTerminal.java
@@ -6,11 +6,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
-import appeng.api.AEApi;
-import appeng.api.networking.IGridNode;
-import appeng.core.features.AEFeature;
-import appeng.core.localization.PlayerMessages;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.common.tabs.FluidCraftingTabs;
 import com.glodblock.github.inventory.gui.GuiType;
@@ -18,6 +13,11 @@ import com.glodblock.github.inventory.item.WirelessInterfaceTerminalInventory;
 import com.glodblock.github.loader.IRegister;
 import com.glodblock.github.util.NameConst;
 import com.glodblock.github.util.Util;
+
+import appeng.api.AEApi;
+import appeng.api.networking.IGridNode;
+import appeng.core.features.AEFeature;
+import appeng.core.localization.PlayerMessages;
 import cpw.mods.fml.common.registry.GameRegistry;
 
 public class ItemWirelessInterfaceTerminal extends ItemBaseWirelessTerminal

--- a/src/main/java/com/glodblock/github/common/item/ItemWirelessPatternTerminal.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemWirelessPatternTerminal.java
@@ -6,11 +6,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
-import appeng.api.AEApi;
-import appeng.api.networking.IGridNode;
-import appeng.core.features.AEFeature;
-import appeng.core.localization.PlayerMessages;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.common.tabs.FluidCraftingTabs;
 import com.glodblock.github.inventory.gui.GuiType;
@@ -18,6 +13,11 @@ import com.glodblock.github.inventory.item.WirelessPatternTerminalInventory;
 import com.glodblock.github.loader.IRegister;
 import com.glodblock.github.util.NameConst;
 import com.glodblock.github.util.Util;
+
+import appeng.api.AEApi;
+import appeng.api.networking.IGridNode;
+import appeng.core.features.AEFeature;
+import appeng.core.localization.PlayerMessages;
 import cpw.mods.fml.common.registry.GameRegistry;
 
 public class ItemWirelessPatternTerminal extends ItemBaseWirelessTerminal

--- a/src/main/java/com/glodblock/github/common/item/ItemWirelessUltraTerminal.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemWirelessUltraTerminal.java
@@ -17,14 +17,6 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
-import appeng.api.AEApi;
-import appeng.api.networking.IGridNode;
-import appeng.core.features.AEFeature;
-import appeng.core.localization.PlayerMessages;
-import appeng.util.Platform;
-import baubles.api.BaubleType;
-import baubles.api.IBauble;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.common.tabs.FluidCraftingTabs;
 import com.glodblock.github.inventory.InventoryHandler;
@@ -37,6 +29,13 @@ import com.glodblock.github.util.ModAndClassUtil;
 import com.glodblock.github.util.NameConst;
 import com.glodblock.github.util.Util;
 
+import appeng.api.AEApi;
+import appeng.api.networking.IGridNode;
+import appeng.core.features.AEFeature;
+import appeng.core.localization.PlayerMessages;
+import appeng.util.Platform;
+import baubles.api.BaubleType;
+import baubles.api.IBauble;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;

--- a/src/main/java/com/glodblock/github/common/parts/PartFluidConversionMonitor.java
+++ b/src/main/java/com/glodblock/github/common/parts/PartFluidConversionMonitor.java
@@ -14,6 +14,9 @@ import net.minecraftforge.fluids.IFluidContainerItem;
 
 import org.apache.commons.lang3.tuple.MutablePair;
 
+import com.glodblock.github.common.item.ItemFluidPacket;
+import com.glodblock.github.util.Util;
+
 import appeng.api.config.Actionable;
 import appeng.api.networking.energy.IEnergySource;
 import appeng.api.networking.security.PlayerSource;
@@ -22,9 +25,6 @@ import appeng.api.storage.data.IAEFluidStack;
 import appeng.me.GridAccessException;
 import appeng.util.InventoryAdaptor;
 import appeng.util.Platform;
-
-import com.glodblock.github.common.item.ItemFluidPacket;
-import com.glodblock.github.util.Util;
 
 public class PartFluidConversionMonitor extends PartFluidStorageMonitor {
 

--- a/src/main/java/com/glodblock/github/common/parts/PartFluidExportBus.java
+++ b/src/main/java/com/glodblock/github/common/parts/PartFluidExportBus.java
@@ -7,6 +7,13 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
 import net.minecraftforge.fluids.IFluidHandler;
 
+import com.glodblock.github.client.textures.FCPartsTexture;
+import com.glodblock.github.common.item.ItemFluidDrop;
+import com.glodblock.github.common.item.ItemFluidPacket;
+import com.glodblock.github.common.parts.base.FCSharedFluidBus;
+import com.glodblock.github.inventory.FluidConvertingInventoryAdaptor;
+import com.google.common.collect.ImmutableSet;
+
 import appeng.api.config.*;
 import appeng.api.networking.IGridNode;
 import appeng.api.networking.crafting.ICraftingGrid;
@@ -30,14 +37,6 @@ import appeng.util.InventoryAdaptor;
 import appeng.util.Platform;
 import appeng.util.item.AEFluidStack;
 import appeng.util.item.AEItemStack;
-
-import com.glodblock.github.client.textures.FCPartsTexture;
-import com.glodblock.github.common.item.ItemFluidDrop;
-import com.glodblock.github.common.item.ItemFluidPacket;
-import com.glodblock.github.common.parts.base.FCSharedFluidBus;
-import com.glodblock.github.inventory.FluidConvertingInventoryAdaptor;
-import com.google.common.collect.ImmutableSet;
-
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 

--- a/src/main/java/com/glodblock/github/common/parts/PartFluidImportBus.java
+++ b/src/main/java/com/glodblock/github/common/parts/PartFluidImportBus.java
@@ -8,6 +8,10 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidHandler;
 
+import com.glodblock.github.client.textures.FCPartsTexture;
+import com.glodblock.github.common.item.ItemFluidPacket;
+import com.glodblock.github.common.parts.base.FCSharedFluidBus;
+
 import appeng.api.config.*;
 import appeng.api.networking.IGridNode;
 import appeng.api.networking.security.BaseActionSource;
@@ -21,11 +25,6 @@ import appeng.api.storage.data.IAEFluidStack;
 import appeng.client.texture.CableBusTextures;
 import appeng.me.GridAccessException;
 import appeng.util.item.AEFluidStack;
-
-import com.glodblock.github.client.textures.FCPartsTexture;
-import com.glodblock.github.common.item.ItemFluidPacket;
-import com.glodblock.github.common.parts.base.FCSharedFluidBus;
-
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 

--- a/src/main/java/com/glodblock/github/common/parts/PartFluidInterface.java
+++ b/src/main/java/com/glodblock/github/common/parts/PartFluidInterface.java
@@ -13,6 +13,17 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 
+import com.glodblock.github.client.textures.FCPartsTexture;
+import com.glodblock.github.common.item.ItemFluidPacket;
+import com.glodblock.github.inventory.AEFluidInventory;
+import com.glodblock.github.inventory.IAEFluidTank;
+import com.glodblock.github.inventory.IDualHost;
+import com.glodblock.github.inventory.InventoryHandler;
+import com.glodblock.github.inventory.gui.GuiType;
+import com.glodblock.github.util.BlockPos;
+import com.glodblock.github.util.DualityFluidInterface;
+import com.glodblock.github.util.Util;
+
 import appeng.api.config.Actionable;
 import appeng.api.config.Upgrades;
 import appeng.api.networking.IGridNode;
@@ -34,18 +45,6 @@ import appeng.parts.misc.PartInterface;
 import appeng.tile.inventory.AppEngInternalAEInventory;
 import appeng.util.Platform;
 import appeng.util.item.AEFluidStack;
-
-import com.glodblock.github.client.textures.FCPartsTexture;
-import com.glodblock.github.common.item.ItemFluidPacket;
-import com.glodblock.github.inventory.AEFluidInventory;
-import com.glodblock.github.inventory.IAEFluidTank;
-import com.glodblock.github.inventory.IDualHost;
-import com.glodblock.github.inventory.InventoryHandler;
-import com.glodblock.github.inventory.gui.GuiType;
-import com.glodblock.github.util.BlockPos;
-import com.glodblock.github.util.DualityFluidInterface;
-import com.glodblock.github.util.Util;
-
 import cpw.mods.fml.common.network.ByteBufUtils;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;

--- a/src/main/java/com/glodblock/github/common/parts/PartFluidLevelEmitter.java
+++ b/src/main/java/com/glodblock/github/common/parts/PartFluidLevelEmitter.java
@@ -17,6 +17,12 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 
+import com.glodblock.github.common.item.ItemFluidPacket;
+import com.glodblock.github.inventory.InventoryHandler;
+import com.glodblock.github.inventory.gui.GuiType;
+import com.glodblock.github.util.BlockPos;
+import com.glodblock.github.util.Util;
+
 import appeng.api.config.*;
 import appeng.api.networking.IGridNode;
 import appeng.api.networking.crafting.*;
@@ -50,13 +56,6 @@ import appeng.parts.automation.PartUpgradeable;
 import appeng.tile.inventory.AppEngInternalAEInventory;
 import appeng.tile.inventory.InvOperation;
 import appeng.util.Platform;
-
-import com.glodblock.github.common.item.ItemFluidPacket;
-import com.glodblock.github.inventory.InventoryHandler;
-import com.glodblock.github.inventory.gui.GuiType;
-import com.glodblock.github.util.BlockPos;
-import com.glodblock.github.util.Util;
-
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 

--- a/src/main/java/com/glodblock/github/common/parts/PartFluidPatternTerminal.java
+++ b/src/main/java/com/glodblock/github/common/parts/PartFluidPatternTerminal.java
@@ -4,17 +4,17 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
-import appeng.api.implementations.ICraftingPatternItem;
-import appeng.api.networking.crafting.ICraftingPatternDetails;
-import appeng.api.storage.data.IAEItemStack;
-import appeng.tile.inventory.BiggerAppEngInventory;
-import appeng.tile.inventory.InvOperation;
-
 import com.glodblock.github.client.textures.FCPartsTexture;
 import com.glodblock.github.common.item.ItemFluidDrop;
 import com.glodblock.github.common.item.ItemFluidPacket;
 import com.glodblock.github.common.parts.base.FCFluidEncodeTerminal;
 import com.glodblock.github.inventory.gui.GuiType;
+
+import appeng.api.implementations.ICraftingPatternItem;
+import appeng.api.networking.crafting.ICraftingPatternDetails;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.tile.inventory.BiggerAppEngInventory;
+import appeng.tile.inventory.InvOperation;
 
 public class PartFluidPatternTerminal extends FCFluidEncodeTerminal {
 

--- a/src/main/java/com/glodblock/github/common/parts/PartFluidPatternTerminalEx.java
+++ b/src/main/java/com/glodblock/github/common/parts/PartFluidPatternTerminalEx.java
@@ -4,17 +4,17 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
-import appeng.api.implementations.ICraftingPatternItem;
-import appeng.api.networking.crafting.ICraftingPatternDetails;
-import appeng.api.storage.data.IAEItemStack;
-import appeng.tile.inventory.BiggerAppEngInventory;
-import appeng.tile.inventory.InvOperation;
-
 import com.glodblock.github.client.textures.FCPartsTexture;
 import com.glodblock.github.common.item.ItemFluidDrop;
 import com.glodblock.github.common.item.ItemFluidPacket;
 import com.glodblock.github.common.parts.base.FCFluidEncodeTerminal;
 import com.glodblock.github.inventory.gui.GuiType;
+
+import appeng.api.implementations.ICraftingPatternItem;
+import appeng.api.networking.crafting.ICraftingPatternDetails;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.tile.inventory.BiggerAppEngInventory;
+import appeng.tile.inventory.InvOperation;
 
 public class PartFluidPatternTerminalEx extends FCFluidEncodeTerminal {
 

--- a/src/main/java/com/glodblock/github/common/parts/PartFluidStorageBus.java
+++ b/src/main/java/com/glodblock/github/common/parts/PartFluidStorageBus.java
@@ -13,6 +13,14 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Vec3;
 import net.minecraftforge.fluids.IFluidHandler;
 
+import com.glodblock.github.client.textures.FCPartsTexture;
+import com.glodblock.github.common.item.ItemFluidPacket;
+import com.glodblock.github.common.tile.TileFluidInterface;
+import com.glodblock.github.inventory.*;
+import com.glodblock.github.inventory.gui.GuiType;
+import com.glodblock.github.util.BlockPos;
+import com.glodblock.github.util.ModAndClassUtil;
+
 import appeng.api.AEApi;
 import appeng.api.config.*;
 import appeng.api.networking.IGridNode;
@@ -49,15 +57,6 @@ import appeng.tile.networking.TileCableBus;
 import appeng.util.Platform;
 import appeng.util.item.AEFluidStack;
 import appeng.util.prioitylist.PrecisePriorityList;
-
-import com.glodblock.github.client.textures.FCPartsTexture;
-import com.glodblock.github.common.item.ItemFluidPacket;
-import com.glodblock.github.common.tile.TileFluidInterface;
-import com.glodblock.github.inventory.*;
-import com.glodblock.github.inventory.gui.GuiType;
-import com.glodblock.github.util.BlockPos;
-import com.glodblock.github.util.ModAndClassUtil;
-
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import extracells.tileentity.TileEntityFluidInterface;

--- a/src/main/java/com/glodblock/github/common/parts/PartFluidStorageMonitor.java
+++ b/src/main/java/com/glodblock/github/common/parts/PartFluidStorageMonitor.java
@@ -2,10 +2,10 @@ package com.glodblock.github.common.parts;
 
 import net.minecraft.item.ItemStack;
 
+import com.glodblock.github.common.parts.base.FCPartMonitor;
+
 import appeng.client.texture.CableBusTextures;
 import appeng.helpers.Reflected;
-
-import com.glodblock.github.common.parts.base.FCPartMonitor;
 
 public class PartFluidStorageMonitor extends FCPartMonitor {
 

--- a/src/main/java/com/glodblock/github/common/parts/base/FCFluidEncodeTerminal.java
+++ b/src/main/java/com/glodblock/github/common/parts/base/FCFluidEncodeTerminal.java
@@ -7,11 +7,11 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
-import appeng.api.storage.data.IAEItemStack;
-import appeng.tile.inventory.AppEngInternalInventory;
-
 import com.glodblock.github.common.item.ItemFluidPacket;
 import com.glodblock.github.inventory.item.IItemPatternTerminal;
+
+import appeng.api.storage.data.IAEItemStack;
+import appeng.tile.inventory.AppEngInternalInventory;
 
 public abstract class FCFluidEncodeTerminal extends FCPart implements IItemPatternTerminal {
 

--- a/src/main/java/com/glodblock/github/common/parts/base/FCPart.java
+++ b/src/main/java/com/glodblock/github/common/parts/base/FCPart.java
@@ -17,6 +17,12 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.util.Vec3;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.glodblock.github.client.textures.FCPartsTexture;
+import com.glodblock.github.inventory.InventoryHandler;
+import com.glodblock.github.inventory.gui.GuiType;
+import com.glodblock.github.util.BlockPos;
+import com.glodblock.github.util.Util;
+
 import appeng.api.config.*;
 import appeng.api.implementations.IPowerChannelState;
 import appeng.api.implementations.tiles.IViewCellStorage;
@@ -41,13 +47,6 @@ import appeng.tile.inventory.InvOperation;
 import appeng.util.ConfigManager;
 import appeng.util.IConfigManagerHost;
 import appeng.util.Platform;
-
-import com.glodblock.github.client.textures.FCPartsTexture;
-import com.glodblock.github.inventory.InventoryHandler;
-import com.glodblock.github.inventory.gui.GuiType;
-import com.glodblock.github.util.BlockPos;
-import com.glodblock.github.util.Util;
-
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/com/glodblock/github/common/parts/base/FCPartMonitor.java
+++ b/src/main/java/com/glodblock/github/common/parts/base/FCPartMonitor.java
@@ -20,6 +20,10 @@ import net.minecraftforge.common.util.ForgeDirection;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
+import com.glodblock.github.client.textures.FCPartsTexture;
+import com.glodblock.github.common.item.ItemFluidPacket;
+import com.glodblock.github.util.Util;
+
 import appeng.api.implementations.parts.IPartStorageMonitor;
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.networking.storage.IStackWatcher;
@@ -43,11 +47,6 @@ import appeng.util.IWideReadableNumberConverter;
 import appeng.util.Platform;
 import appeng.util.ReadableNumberConverter;
 import appeng.util.item.AEFluidStack;
-
-import com.glodblock.github.client.textures.FCPartsTexture;
-import com.glodblock.github.common.item.ItemFluidPacket;
-import com.glodblock.github.util.Util;
-
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import io.netty.buffer.ByteBuf;

--- a/src/main/java/com/glodblock/github/common/parts/base/FCSharedFluidBus.java
+++ b/src/main/java/com/glodblock/github/common/parts/base/FCSharedFluidBus.java
@@ -11,6 +11,11 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
+import com.glodblock.github.common.item.ItemFluidPacket;
+import com.glodblock.github.inventory.InventoryHandler;
+import com.glodblock.github.inventory.gui.GuiType;
+import com.glodblock.github.util.BlockPos;
+
 import appeng.api.config.RedstoneMode;
 import appeng.api.config.Upgrades;
 import appeng.api.networking.ticking.IGridTickable;
@@ -22,11 +27,6 @@ import appeng.me.GridAccessException;
 import appeng.parts.automation.PartUpgradeable;
 import appeng.tile.inventory.AppEngInternalAEInventory;
 import appeng.util.Platform;
-
-import com.glodblock.github.common.item.ItemFluidPacket;
-import com.glodblock.github.inventory.InventoryHandler;
-import com.glodblock.github.inventory.gui.GuiType;
-import com.glodblock.github.util.BlockPos;
 
 public abstract class FCSharedFluidBus extends PartUpgradeable implements IGridTickable {
 

--- a/src/main/java/com/glodblock/github/common/storage/CreativeFluidCellInventory.java
+++ b/src/main/java/com/glodblock/github/common/storage/CreativeFluidCellInventory.java
@@ -4,14 +4,14 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
+import com.glodblock.github.util.Util;
+
 import appeng.api.AEApi;
 import appeng.api.config.Actionable;
 import appeng.api.exceptions.AppEngException;
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.storage.ISaveProvider;
 import appeng.api.storage.data.IAEFluidStack;
-
-import com.glodblock.github.util.Util;
 
 public class CreativeFluidCellInventory extends FluidCellInventory {
 

--- a/src/main/java/com/glodblock/github/common/storage/FluidCellHandler.java
+++ b/src/main/java/com/glodblock/github/common/storage/FluidCellHandler.java
@@ -5,13 +5,13 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
 
-import appeng.api.implementations.tiles.IChestOrDrive;
-import appeng.api.storage.*;
-import appeng.client.texture.ExtraBlockTextures;
-
 import com.glodblock.github.inventory.InventoryHandler;
 import com.glodblock.github.inventory.gui.GuiType;
 import com.glodblock.github.util.BlockPos;
+
+import appeng.api.implementations.tiles.IChestOrDrive;
+import appeng.api.storage.*;
+import appeng.client.texture.ExtraBlockTextures;
 
 public class FluidCellHandler implements ICellHandler {
 

--- a/src/main/java/com/glodblock/github/common/storage/FluidCellInventory.java
+++ b/src/main/java/com/glodblock/github/common/storage/FluidCellInventory.java
@@ -10,6 +10,10 @@ import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.fluids.FluidStack;
 
+import com.glodblock.github.common.item.ItemCreativeFluidStorageCell;
+import com.glodblock.github.crossmod.extracells.storage.ProxyFluidCellInventory;
+import com.glodblock.github.crossmod.extracells.storage.ProxyFluidStorageCell;
+
 import appeng.api.AEApi;
 import appeng.api.config.Actionable;
 import appeng.api.exceptions.AppEngException;
@@ -21,10 +25,6 @@ import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IItemList;
 import appeng.util.Platform;
 import appeng.util.item.AEFluidStack;
-
-import com.glodblock.github.common.item.ItemCreativeFluidStorageCell;
-import com.glodblock.github.crossmod.extracells.storage.ProxyFluidCellInventory;
-import com.glodblock.github.crossmod.extracells.storage.ProxyFluidStorageCell;
 
 public class FluidCellInventory implements IFluidCellInventory {
 

--- a/src/main/java/com/glodblock/github/common/storage/FluidCellInventoryHandler.java
+++ b/src/main/java/com/glodblock/github/common/storage/FluidCellInventoryHandler.java
@@ -3,6 +3,9 @@ package com.glodblock.github.common.storage;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 
+import com.glodblock.github.util.Ae2Reflect;
+import com.glodblock.github.util.Util;
+
 import appeng.api.AEApi;
 import appeng.api.config.IncludeExclude;
 import appeng.api.storage.IMEInventory;
@@ -13,9 +16,6 @@ import appeng.me.storage.MEInventoryHandler;
 import appeng.me.storage.MEPassThrough;
 import appeng.util.item.AEFluidStack;
 import appeng.util.prioitylist.PrecisePriorityList;
-
-import com.glodblock.github.util.Ae2Reflect;
-import com.glodblock.github.util.Util;
 
 public class FluidCellInventoryHandler extends MEInventoryHandler<IAEFluidStack> implements IFluidCellInventoryHandler {
 

--- a/src/main/java/com/glodblock/github/common/tile/TileFluidAutoFiller.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileFluidAutoFiller.java
@@ -17,6 +17,9 @@ import net.minecraftforge.fluids.FluidStack;
 
 import org.apache.commons.lang3.tuple.MutablePair;
 
+import com.glodblock.github.common.item.ItemFluidDrop;
+import com.glodblock.github.util.Util;
+
 import appeng.api.AEApi;
 import appeng.api.config.Actionable;
 import appeng.api.config.PowerMultiplier;
@@ -50,9 +53,6 @@ import appeng.tile.events.TileEventType;
 import appeng.tile.grid.AENetworkInvTile;
 import appeng.tile.inventory.AppEngInternalInventory;
 import appeng.tile.inventory.InvOperation;
-
-import com.glodblock.github.common.item.ItemFluidDrop;
-import com.glodblock.github.util.Util;
 
 public class TileFluidAutoFiller extends AENetworkInvTile
         implements ICraftingProvider, IMEMonitorHandlerReceiver<IAEFluidStack>, IGridTickable {

--- a/src/main/java/com/glodblock/github/common/tile/TileFluidBuffer.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileFluidBuffer.java
@@ -7,6 +7,10 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidHandler;
 
+import com.glodblock.github.inventory.AEFluidInventory;
+import com.glodblock.github.inventory.IAEFluidInventory;
+import com.glodblock.github.inventory.IAEFluidTank;
+
 import appeng.api.config.Actionable;
 import appeng.api.config.PowerMultiplier;
 import appeng.api.implementations.IPowerChannelState;
@@ -22,10 +26,6 @@ import appeng.tile.TileEvent;
 import appeng.tile.events.TileEventType;
 import appeng.tile.grid.AENetworkTile;
 import appeng.util.item.AEFluidStack;
-
-import com.glodblock.github.inventory.AEFluidInventory;
-import com.glodblock.github.inventory.IAEFluidInventory;
-import com.glodblock.github.inventory.IAEFluidTank;
 import io.netty.buffer.ByteBuf;
 
 public class TileFluidBuffer extends AENetworkTile implements IAEFluidInventory, IFluidHandler, IPowerChannelState {

--- a/src/main/java/com/glodblock/github/common/tile/TileFluidDiscretizer.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileFluidDiscretizer.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import com.glodblock.github.common.item.ItemFluidDrop;
+
 import appeng.api.AEApi;
 import appeng.api.config.Actionable;
 import appeng.api.networking.GridFlags;
@@ -24,8 +26,6 @@ import appeng.me.GridAccessException;
 import appeng.me.cache.CraftingGridCache;
 import appeng.me.storage.MEInventoryHandler;
 import appeng.tile.grid.AENetworkTile;
-
-import com.glodblock.github.common.item.ItemFluidDrop;
 
 public class TileFluidDiscretizer extends AENetworkTile implements IPriorityHost, ICellContainer {
 

--- a/src/main/java/com/glodblock/github/common/tile/TileFluidInterface.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileFluidInterface.java
@@ -11,6 +11,14 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 
+import com.glodblock.github.common.item.ItemFluidPacket;
+import com.glodblock.github.inventory.AEFluidInventory;
+import com.glodblock.github.inventory.IAEFluidTank;
+import com.glodblock.github.inventory.IDualHost;
+import com.glodblock.github.loader.ItemAndBlockHolder;
+import com.glodblock.github.util.DualityFluidInterface;
+import com.glodblock.github.util.Util;
+
 import appeng.api.config.Settings;
 import appeng.api.config.SidelessMode;
 import appeng.api.config.Upgrades;
@@ -26,15 +34,6 @@ import appeng.tile.TileEvent;
 import appeng.tile.events.TileEventType;
 import appeng.tile.inventory.AppEngInternalAEInventory;
 import appeng.tile.misc.TileInterface;
-
-import com.glodblock.github.common.item.ItemFluidPacket;
-import com.glodblock.github.inventory.AEFluidInventory;
-import com.glodblock.github.inventory.IAEFluidTank;
-import com.glodblock.github.inventory.IDualHost;
-import com.glodblock.github.loader.ItemAndBlockHolder;
-import com.glodblock.github.util.DualityFluidInterface;
-import com.glodblock.github.util.Util;
-
 import cpw.mods.fml.common.network.ByteBufUtils;
 import io.netty.buffer.ByteBuf;
 

--- a/src/main/java/com/glodblock/github/common/tile/TileFluidPacketDecoder.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileFluidPacketDecoder.java
@@ -7,6 +7,8 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.*;
 
+import com.glodblock.github.common.item.ItemFluidPacket;
+
 import appeng.api.networking.GridFlags;
 import appeng.api.networking.IGridNode;
 import appeng.api.networking.energy.IEnergyGrid;
@@ -28,8 +30,6 @@ import appeng.tile.inventory.IAEAppEngInventory;
 import appeng.tile.inventory.InvOperation;
 import appeng.util.Platform;
 import appeng.util.item.AEFluidStack;
-
-import com.glodblock.github.common.item.ItemFluidPacket;
 
 public class TileFluidPacketDecoder extends AENetworkTile
         implements IGridTickable, IAEAppEngInventory, IInventory, IFluidHandler {

--- a/src/main/java/com/glodblock/github/common/tile/TileFluidPatternEncoder.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileFluidPatternEncoder.java
@@ -7,6 +7,9 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 
+import com.glodblock.github.inventory.AeStackInventory;
+import com.glodblock.github.inventory.AeStackInventoryImpl;
+
 import appeng.api.storage.StorageChannel;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.tile.AEBaseTile;
@@ -15,9 +18,6 @@ import appeng.tile.events.TileEventType;
 import appeng.tile.inventory.AppEngInternalInventory;
 import appeng.tile.inventory.IAEAppEngInventory;
 import appeng.tile.inventory.InvOperation;
-
-import com.glodblock.github.inventory.AeStackInventory;
-import com.glodblock.github.inventory.AeStackInventoryImpl;
 
 public class TileFluidPatternEncoder extends AEBaseTile implements IAEAppEngInventory {
 

--- a/src/main/java/com/glodblock/github/common/tile/TileIngredientBuffer.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileIngredientBuffer.java
@@ -13,16 +13,15 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidHandler;
 
+import com.glodblock.github.inventory.AEFluidInventory;
+import com.glodblock.github.inventory.IAEFluidInventory;
+import com.glodblock.github.inventory.IAEFluidTank;
+
 import appeng.tile.AEBaseInvTile;
 import appeng.tile.TileEvent;
 import appeng.tile.events.TileEventType;
 import appeng.tile.inventory.AppEngInternalInventory;
 import appeng.tile.inventory.InvOperation;
-
-import com.glodblock.github.inventory.AEFluidInventory;
-import com.glodblock.github.inventory.IAEFluidInventory;
-import com.glodblock.github.inventory.IAEFluidTank;
-
 import cpw.mods.fml.common.network.ByteBufUtils;
 import io.netty.buffer.ByteBuf;
 

--- a/src/main/java/com/glodblock/github/common/tile/TileLargeIngredientBuffer.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileLargeIngredientBuffer.java
@@ -2,9 +2,9 @@ package com.glodblock.github.common.tile;
 
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.tile.inventory.AppEngInternalInventory;
-
 import com.glodblock.github.inventory.AEFluidInventory;
+
+import appeng.tile.inventory.AppEngInternalInventory;
 
 public class TileLargeIngredientBuffer extends TileIngredientBuffer {
 

--- a/src/main/java/com/glodblock/github/common/tile/TileLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileLevelMaintainer.java
@@ -6,6 +6,12 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
+import com.glodblock.github.common.item.ItemFluidDrop;
+import com.glodblock.github.inventory.AeItemStackHandler;
+import com.glodblock.github.inventory.AeStackInventory;
+import com.glodblock.github.inventory.AeStackInventoryImpl;
+import com.google.common.collect.ImmutableSet;
+
 import appeng.api.AEApi;
 import appeng.api.config.Actionable;
 import appeng.api.config.PowerMultiplier;
@@ -40,12 +46,6 @@ import appeng.tile.grid.AENetworkTile;
 import appeng.tile.inventory.IAEAppEngInventory;
 import appeng.tile.inventory.InvOperation;
 import appeng.util.item.AEItemStack;
-
-import com.glodblock.github.common.item.ItemFluidDrop;
-import com.glodblock.github.inventory.AeItemStackHandler;
-import com.glodblock.github.inventory.AeStackInventory;
-import com.glodblock.github.inventory.AeStackInventoryImpl;
-import com.google.common.collect.ImmutableSet;
 import io.netty.buffer.ByteBuf;
 
 public class TileLevelMaintainer extends AENetworkTile

--- a/src/main/java/com/glodblock/github/coremod/hooker/CoreModHooks.java
+++ b/src/main/java/com/glodblock/github/coremod/hooker/CoreModHooks.java
@@ -12,6 +12,18 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 
+import com.glodblock.github.client.gui.GuiFluidCraftConfirm;
+import com.glodblock.github.common.item.ItemFluidDrop;
+import com.glodblock.github.common.item.ItemFluidPacket;
+import com.glodblock.github.common.parts.PartFluidInterface;
+import com.glodblock.github.common.tile.TileFluidInterface;
+import com.glodblock.github.inventory.FluidConvertingInventoryAdaptor;
+import com.glodblock.github.inventory.FluidConvertingInventoryCrafting;
+import com.glodblock.github.loader.ItemAndBlockHolder;
+import com.glodblock.github.util.Ae2Reflect;
+import com.glodblock.github.util.SetBackedMachineSet;
+import com.google.common.collect.Sets;
+
 import appeng.api.config.Actionable;
 import appeng.api.networking.IGrid;
 import appeng.api.networking.IGridHost;
@@ -27,18 +39,6 @@ import appeng.me.cluster.implementations.CraftingCPUCluster;
 import appeng.parts.misc.PartInterface;
 import appeng.tile.misc.TileInterface;
 import appeng.util.InventoryAdaptor;
-
-import com.glodblock.github.client.gui.GuiFluidCraftConfirm;
-import com.glodblock.github.common.item.ItemFluidDrop;
-import com.glodblock.github.common.item.ItemFluidPacket;
-import com.glodblock.github.common.parts.PartFluidInterface;
-import com.glodblock.github.common.tile.TileFluidInterface;
-import com.glodblock.github.inventory.FluidConvertingInventoryAdaptor;
-import com.glodblock.github.inventory.FluidConvertingInventoryCrafting;
-import com.glodblock.github.loader.ItemAndBlockHolder;
-import com.glodblock.github.util.Ae2Reflect;
-import com.glodblock.github.util.SetBackedMachineSet;
-import com.google.common.collect.Sets;
 
 public class CoreModHooks {
 

--- a/src/main/java/com/glodblock/github/crossmod/extracells/EC2Replacer.java
+++ b/src/main/java/com/glodblock/github/crossmod/extracells/EC2Replacer.java
@@ -14,7 +14,8 @@ public class EC2Replacer {
      * entire EC2 mod. After running this once, you should set replaceEC2 back to false.
      */
     public static void initReplacer() {
-        ItemReplacements.init();
+        System.out.println("Extra Cells not detected, and configuration set. Replacing extra cells.");
+        ItemReplacements.postinit();
     }
 
     public static void replaceExtraCells(FMLMissingMappingsEvent event) {

--- a/src/main/java/com/glodblock/github/crossmod/extracells/ItemReplacements.java
+++ b/src/main/java/com/glodblock/github/crossmod/extracells/ItemReplacements.java
@@ -4,24 +4,24 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
-import com.glodblock.github.common.item.ItemBaseWirelessTerminal;
-import cpw.mods.fml.common.Loader;
-import cpw.mods.fml.common.Optional;
-import li.cil.oc.OpenComputers;
 import li.cil.oc.api.Items;
 import li.cil.oc.api.detail.ItemInfo;
+
 import net.minecraft.item.Item;
+import net.minecraft.nbt.NBTTagCompound;
 
 import appeng.api.AEApi;
 import appeng.api.definitions.IItemDefinition;
 
+import com.glodblock.github.common.item.ItemBaseWirelessTerminal;
 import com.glodblock.github.common.item.ItemMultiFluidStorageCell;
 import com.glodblock.github.crossmod.extracells.parts.*;
 import com.glodblock.github.crossmod.extracells.storage.*;
 import com.glodblock.github.loader.ItemAndBlockHolder;
+
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.common.registry.GameRegistry;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagDouble;
 
 /**
  * Shell class to organize proxy replacements and hide the ugliness
@@ -102,7 +102,7 @@ public class ItemReplacements {
     /**
      * Deprecate OC upgrades. Wrapper so we don't need a hard dependency
      */
-    @Optional.Method(modid="OpenComputers")
+    @Optional.Method(modid = "OpenComputers")
     static void deprecateOC() {
         ItemInfo info = Items.get("me_upgrade1");
         if (info != null) {
@@ -201,20 +201,19 @@ public class ItemReplacements {
     }
 
     private static void deprecateWireless(String srcName, ItemBaseWirelessTerminal replacement) {
-        getOrBuildItem(srcName).addMetaReplacement(0,
-            new ProxyItem.ProxyItemEntry(replacement, 0) {
-                @Override
-                NBTTagCompound replaceNBT(NBTTagCompound compound) {
-                    double power = compound.getDouble("power");
-                    compound.removeTag("power");
-                    compound.setDouble("internalCurrentPower", power);
-                    String key = compound.getString("key");
-                    compound.removeTag("key");
-                    compound.setString("encryptionKey", key);
-                    return compound;
-                }
+        getOrBuildItem(srcName).addMetaReplacement(0, new ProxyItem.ProxyItemEntry(replacement, 0) {
+
+            @Override
+            NBTTagCompound replaceNBT(NBTTagCompound compound) {
+                double power = compound.getDouble("power");
+                compound.removeTag("power");
+                compound.setDouble("internalCurrentPower", power);
+                String key = compound.getString("key");
+                compound.removeTag("key");
+                compound.setString("encryptionKey", key);
+                return compound;
             }
-        );
+        });
     }
 
     private static void deprecateItemPart(int srcMeta, Item replacement,
@@ -230,7 +229,7 @@ public class ItemReplacements {
     }
 
     private static void deprecateItemPart(int srcMeta, IItemDefinition definition,
-                                          Function<ProxyPartItem, ProxyPart> partBuilder) {
+            Function<ProxyPartItem, ProxyPart> partBuilder) {
         if (definition.isEnabled()) {
             final String fullName = "extracells:part.base";
             ProxyPartItem proxyItem = (ProxyPartItem) registry.get(fullName);

--- a/src/main/java/com/glodblock/github/crossmod/extracells/ItemReplacements.java
+++ b/src/main/java/com/glodblock/github/crossmod/extracells/ItemReplacements.java
@@ -4,14 +4,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
-import li.cil.oc.api.Items;
-import li.cil.oc.api.detail.ItemInfo;
-
 import net.minecraft.item.Item;
 import net.minecraft.nbt.NBTTagCompound;
-
-import appeng.api.AEApi;
-import appeng.api.definitions.IItemDefinition;
 
 import com.glodblock.github.common.item.ItemBaseWirelessTerminal;
 import com.glodblock.github.common.item.ItemMultiFluidStorageCell;
@@ -19,9 +13,13 @@ import com.glodblock.github.crossmod.extracells.parts.*;
 import com.glodblock.github.crossmod.extracells.storage.*;
 import com.glodblock.github.loader.ItemAndBlockHolder;
 
+import appeng.api.AEApi;
+import appeng.api.definitions.IItemDefinition;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.common.registry.GameRegistry;
+import li.cil.oc.api.Items;
+import li.cil.oc.api.detail.ItemInfo;
 
 /**
  * Shell class to organize proxy replacements and hide the ugliness

--- a/src/main/java/com/glodblock/github/crossmod/extracells/ItemReplacements.java
+++ b/src/main/java/com/glodblock/github/crossmod/extracells/ItemReplacements.java
@@ -4,6 +4,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.Optional;
+import li.cil.oc.OpenComputers;
+import li.cil.oc.api.Items;
+import li.cil.oc.api.detail.ItemInfo;
 import net.minecraft.item.Item;
 
 import appeng.api.AEApi;
@@ -22,11 +27,14 @@ public class ItemReplacements {
 
     protected static Map<String, Item> registry;
 
-    static void init() {
+    static void postinit() {
         registry = new HashMap<>(23);
         ProxyFluidBusIO.init();
         ItemReplacements.proxyItems();
         ItemReplacements.proxyPartItems();
+        if (Loader.isModLoaded("OpenComputers")) {
+            deprecateOC();
+        }
     }
 
     /**
@@ -85,6 +93,23 @@ public class ItemReplacements {
         deprecateItem("storage.component", 9, ItemAndBlockHolder.CELL_PART, 5);
         deprecateItem("storage.component", 10, ItemAndBlockHolder.CELL_PART, 6);
         deprecateItem("terminal.universal.wireless", ItemAndBlockHolder.WIRELESS_ULTRA_TERM);
+
+    }
+
+    /**
+     * Deprecate OC upgrades. Wrapper so we don't need a hard dependency
+     */
+    @Optional.Method(modid="OpenComputers")
+    static void deprecateOC() {
+        ItemInfo info = Items.get("me_upgrade1");
+        if (info != null) {
+            // Note EC tier 1, 2, 3 corresponds to the correct meta equivalent in OC, so we can be lazy
+            deprecateItem("oc.upgrade", 0, info.item(), 0);
+            deprecateItem("oc.upgrade", 1, info.item(), 1);
+            deprecateItem("oc.upgrade", 2, info.item(), 2);
+        } else {
+            System.out.println("OpenComputers detected, but could not replace items: me_upgrade1");
+        }
     }
 
     /**

--- a/src/main/java/com/glodblock/github/crossmod/extracells/ItemReplacements.java
+++ b/src/main/java/com/glodblock/github/crossmod/extracells/ItemReplacements.java
@@ -99,6 +99,7 @@ public class ItemReplacements {
         deprecateItemPart(9, ItemAndBlockHolder.FLUID_INTERFACE, ProxyFluidInterface::new);
         deprecateItemPart(10, ItemAndBlockHolder.FLUID_STORAGE_MONITOR, ProxyStorageMonitor::new);
         deprecateItemPart(11, ItemAndBlockHolder.FLUID_CONVERSION_MONITOR, ProxyStorageMonitor::new);
+        deprecateItemPart(12, AEApi.instance().definitions().parts().exportBus(), ProxyOreDictExportBus::new);
     }
 
     private static ProxyItem getOrBuildItem(String srcName) {
@@ -147,7 +148,7 @@ public class ItemReplacements {
 
     /**
      * Deprecate a simple item.
-     * 
+     *
      * @param srcName     name of the to-be-replaced item without the mod id prefix
      * @param srcMeta     meta of the to-be-replaced item
      * @param replacement item that will replace src
@@ -187,6 +188,20 @@ public class ItemReplacements {
         proxyItem.addItemPart(srcMeta, replacement, partBuilder);
     }
 
+    private static void deprecateItemPart(int srcMeta, IItemDefinition definition,
+                                          Function<ProxyPartItem, ProxyPart> partBuilder) {
+        if (definition.isEnabled()) {
+            final String fullName = "extracells:part.base";
+            ProxyPartItem proxyItem = (ProxyPartItem) registry.get(fullName);
+            if (proxyItem == null) {
+                proxyItem = new ProxyPartItem("part.base");
+                registry.put(fullName, proxyItem);
+                proxyItem.register();
+            }
+            proxyItem.addItemPart(srcMeta, definition, partBuilder);
+        }
+    }
+
     /**
      * Deprecate a fluid storage item. Note that we can't access the properties directly, so we need to do this
      */
@@ -195,6 +210,7 @@ public class ItemReplacements {
         ProxyFluidStorageCell proxyItem = getOrBuildFluidStorage(srcName);
         ProxyItem.ProxyStorageEntry entry = new ProxyItem.ProxyStorageEntry(
                 replacement,
+                0,
                 kilobytes,
                 bytesPerType,
                 idleDrain);
@@ -212,6 +228,7 @@ public class ItemReplacements {
             int meta = replacement.maybeStack(1).get().getItemDamage();
             ProxyItem.ProxyItemEntry storage = new ProxyItem.ProxyStorageEntry(
                     replacement.maybeItem().get(),
+                    meta,
                     kilobytes,
                     bytesPerType,
                     idleDrain);
@@ -245,6 +262,7 @@ public class ItemReplacements {
             int meta = replacement.maybeStack(1).get().getItemDamage();
             ProxyItem.ProxyItemEntry storage = new ProxyItem.ProxyStorageEntry(
                     replacement.maybeItem().get(),
+                    meta,
                     bytes / 1024,
                     bytesPerType,
                     idleDrain);

--- a/src/main/java/com/glodblock/github/crossmod/extracells/ItemReplacements.java
+++ b/src/main/java/com/glodblock/github/crossmod/extracells/ItemReplacements.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
+import com.glodblock.github.common.item.ItemBaseWirelessTerminal;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Optional;
 import li.cil.oc.OpenComputers;
@@ -19,6 +20,8 @@ import com.glodblock.github.crossmod.extracells.parts.*;
 import com.glodblock.github.crossmod.extracells.storage.*;
 import com.glodblock.github.loader.ItemAndBlockHolder;
 import cpw.mods.fml.common.registry.GameRegistry;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagDouble;
 
 /**
  * Shell class to organize proxy replacements and hide the ugliness
@@ -76,7 +79,7 @@ public class ItemReplacements {
         GameRegistry.registerItem(voidCell, "ec2placeholder.storage.physical.void");
         registry.put("extracells:storage.physical.void", voidCell);
         deprecateItem("pattern.fluid", ItemAndBlockHolder.PATTERN);
-        deprecateItem("terminal.fluid.wireless", ItemAndBlockHolder.WIRELESS_FLUID_TERM);
+        deprecateWireless("terminal.fluid.wireless", ItemAndBlockHolder.WIRELESS_FLUID_TERM);
         /* Storage casings */
         deprecateItem("storage.casing", 0, AEApi.instance().definitions().materials().emptyAdvancedStorageCell());
         deprecateItem("storage.casing", 1, ItemAndBlockHolder.CELL_HOUSING, 2);
@@ -92,7 +95,7 @@ public class ItemReplacements {
         deprecateItem("storage.component", 8, ItemAndBlockHolder.CELL_PART, 4);
         deprecateItem("storage.component", 9, ItemAndBlockHolder.CELL_PART, 5);
         deprecateItem("storage.component", 10, ItemAndBlockHolder.CELL_PART, 6);
-        deprecateItem("terminal.universal.wireless", ItemAndBlockHolder.WIRELESS_ULTRA_TERM);
+        deprecateWireless("terminal.universal.wireless", ItemAndBlockHolder.WIRELESS_ULTRA_TERM);
 
     }
 
@@ -183,10 +186,6 @@ public class ItemReplacements {
         getOrBuildItem(srcName).addMetaReplacement(srcMeta, replacement, targetMeta);
     }
 
-    static void deprecateItemBlock(String srcName, int srcMeta, Item replacement, int targetMeta) {
-        getOrBuildItem("itemBlock." + srcName).addMetaReplacement(srcMeta, replacement, targetMeta);
-    }
-
     private static void deprecateItem(String srcName, Item replacement) {
         deprecateItem(srcName, 0, replacement, 0);
     }
@@ -199,6 +198,23 @@ public class ItemReplacements {
                     replacement.maybeItem().get(),
                     replacement.maybeStack(1).get().getItemDamage());
         }
+    }
+
+    private static void deprecateWireless(String srcName, ItemBaseWirelessTerminal replacement) {
+        getOrBuildItem(srcName).addMetaReplacement(0,
+            new ProxyItem.ProxyItemEntry(replacement, 0) {
+                @Override
+                NBTTagCompound replaceNBT(NBTTagCompound compound) {
+                    double power = compound.getDouble("power");
+                    compound.removeTag("power");
+                    compound.setDouble("internalCurrentPower", power);
+                    String key = compound.getString("key");
+                    compound.removeTag("key");
+                    compound.setString("encryptionKey", key);
+                    return compound;
+                }
+            }
+        );
     }
 
     private static void deprecateItemPart(int srcMeta, Item replacement,

--- a/src/main/java/com/glodblock/github/crossmod/extracells/ProxyItem.java
+++ b/src/main/java/com/glodblock/github/crossmod/extracells/ProxyItem.java
@@ -101,7 +101,7 @@ public class ProxyItem extends FCBaseItem {
 
         /**
          * Creates a Proxy Replacement.
-         * 
+         *
          * @param replacement     Item that will replace the other.
          * @param replacementMeta Metadata/damage value of the replacement
          */
@@ -123,8 +123,8 @@ public class ProxyItem extends FCBaseItem {
         public final double idleDrain;
         public final int types;
 
-        protected ProxyStorageEntry(Item replacement, long kilobytes, int bytesPerType, double idleDrain) {
-            super(replacement, 0);
+        protected ProxyStorageEntry(Item replacement, int meta, long kilobytes, int bytesPerType, double idleDrain) {
+            super(replacement, meta);
             this.maxBytes = kilobytes * 1024;
             this.bytesPerType = bytesPerType;
             this.idleDrain = idleDrain;

--- a/src/main/java/com/glodblock/github/crossmod/extracells/ProxyItem.java
+++ b/src/main/java/com/glodblock/github/crossmod/extracells/ProxyItem.java
@@ -14,6 +14,7 @@ import net.minecraft.world.World;
 
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.common.item.FCBaseItem;
+
 import cpw.mods.fml.common.registry.GameRegistry;
 
 /**

--- a/src/main/java/com/glodblock/github/crossmod/extracells/ProxyPartItem.java
+++ b/src/main/java/com/glodblock/github/crossmod/extracells/ProxyPartItem.java
@@ -2,12 +2,12 @@ package com.glodblock.github.crossmod.extracells;
 
 import java.util.function.Function;
 
-import appeng.api.definitions.IItemDefinition;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
 import org.jetbrains.annotations.Nullable;
 
+import appeng.api.definitions.IItemDefinition;
 import appeng.api.parts.IPart;
 import appeng.api.parts.IPartItem;
 
@@ -37,6 +37,7 @@ public class ProxyPartItem extends ProxyItem implements IPartItem {
         ItemStack stack = replacement.maybeStack(1).get();
         this.replacements.put(srcMeta, new PartReplacement(stack.getItem(), stack.getItemDamage(), part));
     }
+
     @Nullable
     @Override
     public IPart createPartFromItemStack(ItemStack is) {

--- a/src/main/java/com/glodblock/github/crossmod/extracells/ProxyPartItem.java
+++ b/src/main/java/com/glodblock/github/crossmod/extracells/ProxyPartItem.java
@@ -2,6 +2,7 @@ package com.glodblock.github.crossmod.extracells;
 
 import java.util.function.Function;
 
+import appeng.api.definitions.IItemDefinition;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
@@ -15,7 +16,7 @@ public class ProxyPartItem extends ProxyItem implements IPartItem {
     /**
      * Creates a ProxyPartItem associated with the ProxyPart instance. This instance is reused on each call to
      * {@link #createPartFromItemStack(ItemStack)}.
-     * 
+     *
      * @param ec2itemName extra cells internal name
      */
     public ProxyPartItem(String ec2itemName) {
@@ -32,6 +33,10 @@ public class ProxyPartItem extends ProxyItem implements IPartItem {
         this.replacements.put(srcMeta, new PartReplacement(replacement, part));
     }
 
+    protected void addItemPart(int srcMeta, IItemDefinition replacement, Function<ProxyPartItem, ProxyPart> part) {
+        ItemStack stack = replacement.maybeStack(1).get();
+        this.replacements.put(srcMeta, new PartReplacement(stack.getItem(), stack.getItemDamage(), part));
+    }
     @Nullable
     @Override
     public IPart createPartFromItemStack(ItemStack is) {
@@ -52,7 +57,11 @@ class PartReplacement extends ProxyItem.ProxyItemEntry {
     Function<ProxyPartItem, ProxyPart> proxyPart;
 
     PartReplacement(Item replacement, Function<ProxyPartItem, ProxyPart> proxyPart) {
-        super(replacement, 0);
+        this(replacement, 0, proxyPart);
+    }
+
+    PartReplacement(Item replacement, int meta, Function<ProxyPartItem, ProxyPart> proxyPart) {
+        super(replacement, meta);
         this.proxyPart = proxyPart;
     }
 }

--- a/src/main/java/com/glodblock/github/crossmod/extracells/parts/ProxyFluidBusIO.java
+++ b/src/main/java/com/glodblock/github/crossmod/extracells/parts/ProxyFluidBusIO.java
@@ -5,10 +5,10 @@ import static net.minecraftforge.common.util.Constants.NBT.TAG_COMPOUND;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 
-import appeng.api.config.RedstoneMode;
-
 import com.glodblock.github.crossmod.extracells.ProxyPart;
 import com.glodblock.github.crossmod.extracells.ProxyPartItem;
+
+import appeng.api.config.RedstoneMode;
 
 public class ProxyFluidBusIO extends ProxyPart {
 

--- a/src/main/java/com/glodblock/github/crossmod/extracells/parts/ProxyLevelEmitter.java
+++ b/src/main/java/com/glodblock/github/crossmod/extracells/parts/ProxyLevelEmitter.java
@@ -2,10 +2,10 @@ package com.glodblock.github.crossmod.extracells.parts;
 
 import net.minecraft.nbt.NBTTagCompound;
 
-import appeng.api.config.RedstoneMode;
-
 import com.glodblock.github.crossmod.extracells.ProxyPart;
 import com.glodblock.github.crossmod.extracells.ProxyPartItem;
+
+import appeng.api.config.RedstoneMode;
 
 public class ProxyLevelEmitter extends ProxyPart {
 

--- a/src/main/java/com/glodblock/github/crossmod/extracells/parts/ProxyOreDictExportBus.java
+++ b/src/main/java/com/glodblock/github/crossmod/extracells/parts/ProxyOreDictExportBus.java
@@ -1,0 +1,27 @@
+package com.glodblock.github.crossmod.extracells.parts;
+
+import appeng.api.AEApi;
+import com.glodblock.github.crossmod.extracells.ProxyPart;
+import com.glodblock.github.crossmod.extracells.ProxyPartItem;
+import net.minecraft.nbt.NBTTagCompound;
+
+public class ProxyOreDictExportBus extends ProxyPart {
+
+    public ProxyOreDictExportBus(ProxyPartItem item) {
+        super(item);
+    }
+
+    @Override
+    public NBTTagCompound transformNBT(NBTTagCompound extra) {
+        // Node tag... should've used OOP here but im too lazy to fix it now
+        extra.setTag("part", extra.getCompoundTag("node").getCompoundTag("node0"));
+        extra.removeTag("node");
+        // Ore dict card
+        NBTTagCompound upgrades = new NBTTagCompound();
+        NBTTagCompound oreDictCard = new NBTTagCompound();
+        AEApi.instance().definitions().materials().cardOreFilter().maybeStack(1).get().writeToNBT(oreDictCard);
+        upgrades.setTag("#0", oreDictCard);
+        extra.setTag("upgrades", upgrades);
+        return super.transformNBT(extra);
+    }
+}

--- a/src/main/java/com/glodblock/github/crossmod/extracells/parts/ProxyOreDictExportBus.java
+++ b/src/main/java/com/glodblock/github/crossmod/extracells/parts/ProxyOreDictExportBus.java
@@ -1,9 +1,11 @@
 package com.glodblock.github.crossmod.extracells.parts;
 
+import net.minecraft.nbt.NBTTagCompound;
+
 import appeng.api.AEApi;
+
 import com.glodblock.github.crossmod.extracells.ProxyPart;
 import com.glodblock.github.crossmod.extracells.ProxyPartItem;
-import net.minecraft.nbt.NBTTagCompound;
 
 public class ProxyOreDictExportBus extends ProxyPart {
 

--- a/src/main/java/com/glodblock/github/crossmod/extracells/parts/ProxyOreDictExportBus.java
+++ b/src/main/java/com/glodblock/github/crossmod/extracells/parts/ProxyOreDictExportBus.java
@@ -2,10 +2,10 @@ package com.glodblock.github.crossmod.extracells.parts;
 
 import net.minecraft.nbt.NBTTagCompound;
 
-import appeng.api.AEApi;
-
 import com.glodblock.github.crossmod.extracells.ProxyPart;
 import com.glodblock.github.crossmod.extracells.ProxyPartItem;
+
+import appeng.api.AEApi;
 
 public class ProxyOreDictExportBus extends ProxyPart {
 

--- a/src/main/java/com/glodblock/github/crossmod/extracells/storage/ProxyFluidCellInventory.java
+++ b/src/main/java/com/glodblock/github/crossmod/extracells/storage/ProxyFluidCellInventory.java
@@ -5,13 +5,13 @@ import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.fluids.FluidStack;
 
+import com.glodblock.github.common.storage.FluidCellInventory;
+
 import appeng.api.AEApi;
 import appeng.api.exceptions.AppEngException;
 import appeng.api.storage.ISaveProvider;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.util.item.AEFluidStack;
-
-import com.glodblock.github.common.storage.FluidCellInventory;
 
 public class ProxyFluidCellInventory extends FluidCellInventory {
 

--- a/src/main/java/com/glodblock/github/crossmod/extracells/storage/ProxyFluidStorageCell.java
+++ b/src/main/java/com/glodblock/github/crossmod/extracells/storage/ProxyFluidStorageCell.java
@@ -3,16 +3,16 @@ package com.glodblock.github.crossmod.extracells.storage;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 
+import com.glodblock.github.common.Config;
+import com.glodblock.github.common.storage.IStorageFluidCell;
+import com.glodblock.github.crossmod.extracells.ProxyItem;
+import com.glodblock.github.util.ModAndClassUtil;
+
 import appeng.api.config.FuzzyMode;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.items.contents.CellConfig;
 import appeng.items.contents.CellUpgrades;
 import appeng.util.Platform;
-
-import com.glodblock.github.common.Config;
-import com.glodblock.github.common.storage.IStorageFluidCell;
-import com.glodblock.github.crossmod.extracells.ProxyItem;
-import com.glodblock.github.util.ModAndClassUtil;
 
 public class ProxyFluidStorageCell extends ProxyItem implements IStorageFluidCell {
 

--- a/src/main/java/com/glodblock/github/crossmod/extracells/storage/ProxyItemStorageCell.java
+++ b/src/main/java/com/glodblock/github/crossmod/extracells/storage/ProxyItemStorageCell.java
@@ -5,14 +5,14 @@ import javax.annotation.Nullable;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 
+import com.glodblock.github.crossmod.extracells.ProxyItem;
+
 import appeng.api.config.FuzzyMode;
 import appeng.api.implementations.items.IStorageCell;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.items.contents.CellConfig;
 import appeng.items.contents.CellUpgrades;
 import appeng.util.Platform;
-
-import com.glodblock.github.crossmod.extracells.ProxyItem;
 
 /**
  * Proxy Item Storage. 256K, 1024K, etc. -> AE2's version. For now its just mirroring AE2's version, will need to

--- a/src/main/java/com/glodblock/github/crossmod/opencomputers/DriverDualFluidInterface.java
+++ b/src/main/java/com/glodblock/github/crossmod/opencomputers/DriverDualFluidInterface.java
@@ -1,5 +1,19 @@
 package com.glodblock.github.crossmod.opencomputers;
 
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraftforge.fluids.FluidStack;
+
+import com.glodblock.github.common.parts.PartFluidInterface;
+import com.glodblock.github.common.tile.TileFluidInterface;
+import com.glodblock.github.loader.ItemAndBlockHolder;
+import com.glodblock.github.util.DualityFluidInterface;
+import com.glodblock.github.util.NameConst;
+import com.glodblock.github.util.Util;
+
+import appeng.api.parts.IPartHost;
 import li.cil.oc.api.driver.EnvironmentProvider;
 import li.cil.oc.api.driver.NamedBlock;
 import li.cil.oc.api.driver.SidedBlock;
@@ -11,21 +25,6 @@ import li.cil.oc.api.network.ManagedEnvironment;
 import li.cil.oc.api.network.Node;
 import li.cil.oc.integration.ManagedTileEntityEnvironment;
 import li.cil.oc.server.network.Component;
-
-import net.minecraft.item.ItemStack;
-import net.minecraft.tileentity.TileEntity;
-import net.minecraft.world.World;
-import net.minecraftforge.common.util.ForgeDirection;
-import net.minecraftforge.fluids.FluidStack;
-
-import appeng.api.parts.IPartHost;
-
-import com.glodblock.github.common.parts.PartFluidInterface;
-import com.glodblock.github.common.tile.TileFluidInterface;
-import com.glodblock.github.loader.ItemAndBlockHolder;
-import com.glodblock.github.util.DualityFluidInterface;
-import com.glodblock.github.util.NameConst;
-import com.glodblock.github.util.Util;
 
 public class DriverDualFluidInterface implements SidedBlock {
 

--- a/src/main/java/com/glodblock/github/crossmod/opencomputers/DriverLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/crossmod/opencomputers/DriverLevelMaintainer.java
@@ -3,6 +3,19 @@ package com.glodblock.github.crossmod.opencomputers;
 import java.util.HashMap;
 import java.util.Map;
 
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import com.glodblock.github.common.item.ItemFluidDrop;
+import com.glodblock.github.common.tile.TileLevelMaintainer;
+import com.glodblock.github.inventory.AeItemStackHandler;
+import com.glodblock.github.loader.ItemAndBlockHolder;
+import com.glodblock.github.util.NameConst;
+
+import appeng.util.item.AEItemStack;
+import cpw.mods.fml.common.registry.GameRegistry;
 import li.cil.oc.api.driver.EnvironmentProvider;
 import li.cil.oc.api.driver.NamedBlock;
 import li.cil.oc.api.internal.Database;
@@ -14,20 +27,6 @@ import li.cil.oc.api.network.ManagedEnvironment;
 import li.cil.oc.api.network.Node;
 import li.cil.oc.api.prefab.DriverSidedTileEntity;
 import li.cil.oc.integration.ManagedTileEntityEnvironment;
-
-import net.minecraft.inventory.IInventory;
-import net.minecraft.item.ItemStack;
-import net.minecraft.world.World;
-import net.minecraftforge.common.util.ForgeDirection;
-
-import appeng.util.item.AEItemStack;
-
-import com.glodblock.github.common.item.ItemFluidDrop;
-import com.glodblock.github.common.tile.TileLevelMaintainer;
-import com.glodblock.github.inventory.AeItemStackHandler;
-import com.glodblock.github.loader.ItemAndBlockHolder;
-import com.glodblock.github.util.NameConst;
-import cpw.mods.fml.common.registry.GameRegistry;
 
 public class DriverLevelMaintainer extends DriverSidedTileEntity {
 

--- a/src/main/java/com/glodblock/github/crossmod/opencomputers/DriverOCPatternEditor.java
+++ b/src/main/java/com/glodblock/github/crossmod/opencomputers/DriverOCPatternEditor.java
@@ -1,5 +1,22 @@
 package com.glodblock.github.crossmod.opencomputers;
 
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraftforge.fluids.FluidStack;
+
+import com.glodblock.github.common.item.ItemFluidDrop;
+import com.glodblock.github.common.item.ItemFluidEncodedPattern;
+import com.glodblock.github.common.tile.TileOCPatternEditor;
+import com.glodblock.github.loader.ItemAndBlockHolder;
+import com.glodblock.github.util.NameConst;
+import com.glodblock.github.util.Util;
+
+import appeng.items.misc.ItemEncodedPattern;
+import appeng.util.item.AEItemStack;
 import li.cil.oc.api.driver.EnvironmentProvider;
 import li.cil.oc.api.driver.NamedBlock;
 import li.cil.oc.api.internal.Database;
@@ -11,24 +28,6 @@ import li.cil.oc.api.network.ManagedEnvironment;
 import li.cil.oc.api.network.Node;
 import li.cil.oc.api.prefab.DriverSidedTileEntity;
 import li.cil.oc.integration.ManagedTileEntityEnvironment;
-
-import net.minecraft.inventory.IInventory;
-import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
-import net.minecraft.world.World;
-import net.minecraftforge.common.util.ForgeDirection;
-import net.minecraftforge.fluids.FluidStack;
-
-import appeng.items.misc.ItemEncodedPattern;
-import appeng.util.item.AEItemStack;
-
-import com.glodblock.github.common.item.ItemFluidDrop;
-import com.glodblock.github.common.item.ItemFluidEncodedPattern;
-import com.glodblock.github.common.tile.TileOCPatternEditor;
-import com.glodblock.github.loader.ItemAndBlockHolder;
-import com.glodblock.github.util.NameConst;
-import com.glodblock.github.util.Util;
 
 public class DriverOCPatternEditor extends DriverSidedTileEntity {
 

--- a/src/main/java/com/glodblock/github/crossmod/thaumcraft/AspectRender.java
+++ b/src/main/java/com/glodblock/github/crossmod/thaumcraft/AspectRender.java
@@ -6,10 +6,10 @@ import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
 
+import com.glodblock.github.util.RenderUtil;
+
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.client.lib.UtilsFX;
-
-import com.glodblock.github.util.RenderUtil;
 
 public class AspectRender {
 

--- a/src/main/java/com/glodblock/github/crossmod/thaumcraft/AspectUtil.java
+++ b/src/main/java/com/glodblock/github/crossmod/thaumcraft/AspectUtil.java
@@ -9,6 +9,8 @@ import net.minecraftforge.fluids.FluidStack;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.MutablePair;
 
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.util.item.AEFluidStack;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.IEssentiaContainerItem;
 import thaumcraft.common.Thaumcraft;
@@ -16,8 +18,6 @@ import thaumicenergistics.api.storage.IAspectStack;
 import thaumicenergistics.common.fluids.GaseousEssentia;
 import thaumicenergistics.common.integration.tc.EssentiaItemContainerHelper;
 import thaumicenergistics.common.storage.AspectStack;
-import appeng.api.storage.data.IAEFluidStack;
-import appeng.util.item.AEFluidStack;
 
 public class AspectUtil {
 

--- a/src/main/java/com/glodblock/github/crossmod/waila/FCTooltipHandlerWaila.java
+++ b/src/main/java/com/glodblock/github/crossmod/waila/FCTooltipHandlerWaila.java
@@ -2,8 +2,6 @@ package com.glodblock.github.crossmod.waila;
 
 import java.util.List;
 
-import mcp.mobius.waila.handlers.nei.TooltipHandlerWaila;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
@@ -12,6 +10,8 @@ import net.minecraftforge.fluids.FluidStack;
 
 import com.glodblock.github.common.item.ItemFluidDrop;
 import com.glodblock.github.util.Util;
+
+import mcp.mobius.waila.handlers.nei.TooltipHandlerWaila;
 
 public class FCTooltipHandlerWaila extends TooltipHandlerWaila {
 

--- a/src/main/java/com/glodblock/github/crossmod/waila/PartWailaDataProvider.java
+++ b/src/main/java/com/glodblock/github/crossmod/waila/PartWailaDataProvider.java
@@ -2,10 +2,6 @@ package com.glodblock.github.crossmod.waila;
 
 import java.util.List;
 
-import mcp.mobius.waila.api.IWailaConfigHandler;
-import mcp.mobius.waila.api.IWailaDataAccessor;
-import mcp.mobius.waila.api.IWailaDataProvider;
-
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -13,16 +9,19 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
 
-import appeng.api.parts.IPart;
-import appeng.integration.modules.waila.part.IPartWailaDataProvider;
-import appeng.integration.modules.waila.part.PartAccessor;
-import appeng.integration.modules.waila.part.Tracer;
-
 import com.glodblock.github.crossmod.waila.part.FluidInvWailaDataProvider;
 import com.glodblock.github.crossmod.waila.part.FluidMonitorWailaDataProvider;
 import com.glodblock.github.crossmod.waila.part.SpeedWailaDataProvider;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
+
+import appeng.api.parts.IPart;
+import appeng.integration.modules.waila.part.IPartWailaDataProvider;
+import appeng.integration.modules.waila.part.PartAccessor;
+import appeng.integration.modules.waila.part.Tracer;
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
+import mcp.mobius.waila.api.IWailaDataProvider;
 
 public class PartWailaDataProvider implements IWailaDataProvider {
 

--- a/src/main/java/com/glodblock/github/crossmod/waila/TileWailaDataProvider.java
+++ b/src/main/java/com/glodblock/github/crossmod/waila/TileWailaDataProvider.java
@@ -2,10 +2,6 @@ package com.glodblock.github.crossmod.waila;
 
 import java.util.List;
 
-import mcp.mobius.waila.api.IWailaConfigHandler;
-import mcp.mobius.waila.api.IWailaDataAccessor;
-import mcp.mobius.waila.api.IWailaDataProvider;
-
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -15,6 +11,10 @@ import net.minecraft.world.World;
 import com.glodblock.github.crossmod.waila.tile.FluidInvWailaDataProvider;
 import com.glodblock.github.crossmod.waila.tile.LevelMaintainerWailaDataProvide;
 import com.google.common.collect.Lists;
+
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
+import mcp.mobius.waila.api.IWailaDataProvider;
 
 public class TileWailaDataProvider implements IWailaDataProvider {
 

--- a/src/main/java/com/glodblock/github/crossmod/waila/VanillaTileWailaDataProvider.java
+++ b/src/main/java/com/glodblock/github/crossmod/waila/VanillaTileWailaDataProvider.java
@@ -2,10 +2,6 @@ package com.glodblock.github.crossmod.waila;
 
 import java.util.List;
 
-import mcp.mobius.waila.api.IWailaConfigHandler;
-import mcp.mobius.waila.api.IWailaDataAccessor;
-import mcp.mobius.waila.api.IWailaDataProvider;
-
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -14,6 +10,10 @@ import net.minecraft.world.World;
 
 import com.glodblock.github.crossmod.waila.vanilla.FluidInvWailaDataProvider;
 import com.google.common.collect.Lists;
+
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
+import mcp.mobius.waila.api.IWailaDataProvider;
 
 public class VanillaTileWailaDataProvider implements IWailaDataProvider {
 

--- a/src/main/java/com/glodblock/github/crossmod/waila/WailaInit.java
+++ b/src/main/java/com/glodblock/github/crossmod/waila/WailaInit.java
@@ -1,8 +1,5 @@
 package com.glodblock.github.crossmod.waila;
 
-import mcp.mobius.waila.api.IWailaDataProvider;
-import mcp.mobius.waila.api.IWailaRegistrar;
-
 import net.minecraft.tileentity.TileEntity;
 
 import appeng.api.parts.IPartHost;
@@ -10,6 +7,8 @@ import appeng.tile.AEBaseTile;
 import appeng.util.Platform;
 import codechicken.nei.guihook.GuiContainerManager;
 import cpw.mods.fml.common.event.FMLInterModComms;
+import mcp.mobius.waila.api.IWailaDataProvider;
+import mcp.mobius.waila.api.IWailaRegistrar;
 
 public class WailaInit {
 

--- a/src/main/java/com/glodblock/github/crossmod/waila/part/FluidInvWailaDataProvider.java
+++ b/src/main/java/com/glodblock/github/crossmod/waila/part/FluidInvWailaDataProvider.java
@@ -2,21 +2,20 @@ package com.glodblock.github.crossmod.waila.part;
 
 import java.util.List;
 
-import mcp.mobius.waila.api.IWailaConfigHandler;
-import mcp.mobius.waila.api.IWailaDataAccessor;
-
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidStack;
 
-import appeng.api.parts.IPart;
-import appeng.integration.modules.waila.part.BasePartWailaDataProvider;
-
 import com.glodblock.github.crossmod.waila.Tooltip;
 import com.glodblock.github.inventory.AEFluidInventory;
 import com.glodblock.github.inventory.IAEFluidInventory;
+
+import appeng.api.parts.IPart;
+import appeng.integration.modules.waila.part.BasePartWailaDataProvider;
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
 
 public class FluidInvWailaDataProvider extends BasePartWailaDataProvider {
 

--- a/src/main/java/com/glodblock/github/crossmod/waila/part/FluidMonitorWailaDataProvider.java
+++ b/src/main/java/com/glodblock/github/crossmod/waila/part/FluidMonitorWailaDataProvider.java
@@ -2,21 +2,20 @@ package com.glodblock.github.crossmod.waila.part;
 
 import java.util.List;
 
-import mcp.mobius.waila.api.IWailaConfigHandler;
-import mcp.mobius.waila.api.IWailaDataAccessor;
-
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
-import appeng.api.parts.IPart;
-import appeng.api.storage.data.IAEFluidStack;
-import appeng.integration.modules.waila.part.BasePartWailaDataProvider;
-
 import com.glodblock.github.common.parts.base.FCPartMonitor;
 import com.glodblock.github.crossmod.waila.Tooltip;
 import com.glodblock.github.util.Util;
+
+import appeng.api.parts.IPart;
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.integration.modules.waila.part.BasePartWailaDataProvider;
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
 
 public class FluidMonitorWailaDataProvider extends BasePartWailaDataProvider {
 

--- a/src/main/java/com/glodblock/github/crossmod/waila/part/SpeedWailaDataProvider.java
+++ b/src/main/java/com/glodblock/github/crossmod/waila/part/SpeedWailaDataProvider.java
@@ -2,19 +2,18 @@ package com.glodblock.github.crossmod.waila.part;
 
 import java.util.List;
 
-import mcp.mobius.waila.api.IWailaConfigHandler;
-import mcp.mobius.waila.api.IWailaDataAccessor;
-
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
-import appeng.api.parts.IPart;
-import appeng.integration.modules.waila.part.BasePartWailaDataProvider;
-
 import com.glodblock.github.common.parts.base.FCSharedFluidBus;
 import com.glodblock.github.crossmod.waila.Tooltip;
+
+import appeng.api.parts.IPart;
+import appeng.integration.modules.waila.part.BasePartWailaDataProvider;
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
 
 public class SpeedWailaDataProvider extends BasePartWailaDataProvider {
 

--- a/src/main/java/com/glodblock/github/crossmod/waila/tile/FluidInvWailaDataProvider.java
+++ b/src/main/java/com/glodblock/github/crossmod/waila/tile/FluidInvWailaDataProvider.java
@@ -2,9 +2,6 @@ package com.glodblock.github.crossmod.waila.tile;
 
 import java.util.List;
 
-import mcp.mobius.waila.api.IWailaConfigHandler;
-import mcp.mobius.waila.api.IWailaDataAccessor;
-
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
@@ -13,8 +10,6 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidStack;
 
-import appeng.integration.modules.waila.BaseWailaDataProvider;
-
 import com.glodblock.github.common.item.ItemFluidPacket;
 import com.glodblock.github.common.tile.TileFluidBuffer;
 import com.glodblock.github.common.tile.TileFluidInterface;
@@ -22,6 +17,10 @@ import com.glodblock.github.common.tile.TileFluidPacketDecoder;
 import com.glodblock.github.crossmod.waila.Tooltip;
 import com.glodblock.github.inventory.IAEFluidInventory;
 import com.glodblock.github.inventory.IAEFluidTank;
+
+import appeng.integration.modules.waila.BaseWailaDataProvider;
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
 
 public class FluidInvWailaDataProvider extends BaseWailaDataProvider {
 

--- a/src/main/java/com/glodblock/github/crossmod/waila/tile/LevelMaintainerWailaDataProvide.java
+++ b/src/main/java/com/glodblock/github/crossmod/waila/tile/LevelMaintainerWailaDataProvide.java
@@ -2,20 +2,19 @@ package com.glodblock.github.crossmod.waila.tile;
 
 import java.util.List;
 
-import mcp.mobius.waila.api.IWailaConfigHandler;
-import mcp.mobius.waila.api.IWailaDataAccessor;
-
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
-import appeng.api.storage.data.IAEItemStack;
-import appeng.integration.modules.waila.BaseWailaDataProvider;
-
 import com.glodblock.github.common.tile.TileLevelMaintainer;
 import com.glodblock.github.crossmod.waila.Tooltip;
+
+import appeng.api.storage.data.IAEItemStack;
+import appeng.integration.modules.waila.BaseWailaDataProvider;
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
 
 public class LevelMaintainerWailaDataProvide extends BaseWailaDataProvider {
 

--- a/src/main/java/com/glodblock/github/crossmod/waila/vanilla/FluidInvWailaDataProvider.java
+++ b/src/main/java/com/glodblock/github/crossmod/waila/vanilla/FluidInvWailaDataProvider.java
@@ -2,9 +2,6 @@ package com.glodblock.github.crossmod.waila.vanilla;
 
 import java.util.List;
 
-import mcp.mobius.waila.api.IWailaConfigHandler;
-import mcp.mobius.waila.api.IWailaDataAccessor;
-
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -12,11 +9,13 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidTankInfo;
 
-import appeng.integration.modules.waila.BaseWailaDataProvider;
-
 import com.glodblock.github.common.tile.TileCertusQuartzTank;
 import com.glodblock.github.crossmod.waila.Tooltip;
 import com.glodblock.github.util.Util;
+
+import appeng.integration.modules.waila.BaseWailaDataProvider;
+import mcp.mobius.waila.api.IWailaConfigHandler;
+import mcp.mobius.waila.api.IWailaDataAccessor;
 
 public class FluidInvWailaDataProvider extends BaseWailaDataProvider {
 

--- a/src/main/java/com/glodblock/github/inventory/AEFluidInventory.java
+++ b/src/main/java/com/glodblock/github/inventory/AEFluidInventory.java
@@ -9,12 +9,12 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidTank;
 
+import com.glodblock.github.util.Util;
+
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.core.AELog;
 import appeng.util.Platform;
 import appeng.util.item.AEFluidStack;
-
-import com.glodblock.github.util.Util;
 import io.netty.buffer.ByteBuf;
 
 public class AEFluidInventory implements IAEFluidTank {

--- a/src/main/java/com/glodblock/github/inventory/AeStackInventoryImpl.java
+++ b/src/main/java/com/glodblock/github/inventory/AeStackInventoryImpl.java
@@ -10,13 +10,13 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraftforge.common.util.Constants;
 
+import com.glodblock.github.util.ObjectArrayIterator;
+import com.glodblock.github.util.Util;
+
 import appeng.api.storage.StorageChannel;
 import appeng.api.storage.data.IAEStack;
 import appeng.tile.inventory.IAEAppEngInventory;
 import appeng.util.item.AEItemStack;
-
-import com.glodblock.github.util.ObjectArrayIterator;
-import com.glodblock.github.util.Util;
 
 public class AeStackInventoryImpl<T extends IAEStack<T>> implements AeStackInventory<T> {
 

--- a/src/main/java/com/glodblock/github/inventory/FluidConvertingInventoryAdaptor.java
+++ b/src/main/java/com/glodblock/github/inventory/FluidConvertingInventoryAdaptor.java
@@ -13,6 +13,16 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidHandler;
 
+import com.glodblock.github.common.Config;
+import com.glodblock.github.common.item.ItemFluidPacket;
+import com.glodblock.github.common.parts.PartFluidExportBus;
+import com.glodblock.github.common.parts.PartFluidInterface;
+import com.glodblock.github.common.tile.TileFluidInterface;
+import com.glodblock.github.util.Ae2Reflect;
+import com.glodblock.github.util.BlockPos;
+import com.glodblock.github.util.ModAndClassUtil;
+import com.glodblock.github.util.Util;
+
 import appeng.api.config.*;
 import appeng.api.parts.IPart;
 import appeng.helpers.DualityInterface;
@@ -26,17 +36,6 @@ import appeng.util.InventoryAdaptor;
 import appeng.util.inv.IInventoryDestination;
 import appeng.util.inv.ItemSlot;
 import cofh.api.transport.IItemDuct;
-
-import com.glodblock.github.common.Config;
-import com.glodblock.github.common.item.ItemFluidPacket;
-import com.glodblock.github.common.parts.PartFluidExportBus;
-import com.glodblock.github.common.parts.PartFluidInterface;
-import com.glodblock.github.common.tile.TileFluidInterface;
-import com.glodblock.github.util.Ae2Reflect;
-import com.glodblock.github.util.BlockPos;
-import com.glodblock.github.util.ModAndClassUtil;
-import com.glodblock.github.util.Util;
-
 import crazypants.enderio.conduit.item.IItemConduit;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;

--- a/src/main/java/com/glodblock/github/inventory/IDualHost.java
+++ b/src/main/java/com/glodblock/github/inventory/IDualHost.java
@@ -2,10 +2,10 @@ package com.glodblock.github.inventory;
 
 import net.minecraftforge.fluids.IFluidHandler;
 
+import com.glodblock.github.util.DualityFluidInterface;
+
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.tile.inventory.AppEngInternalAEInventory;
-
-import com.glodblock.github.util.DualityFluidInterface;
 
 public interface IDualHost extends IFluidHandler, IAEFluidInventory {
 

--- a/src/main/java/com/glodblock/github/inventory/InventoryHandler.java
+++ b/src/main/java/com/glodblock/github/inventory/InventoryHandler.java
@@ -6,13 +6,12 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.util.Platform;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.inventory.gui.GuiType;
 import com.glodblock.github.network.CPacketSwitchGuis;
 import com.glodblock.github.util.BlockPos;
 
+import appeng.util.Platform;
 import cpw.mods.fml.common.network.IGuiHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;

--- a/src/main/java/com/glodblock/github/inventory/ItemBiggerAppEngInventory.java
+++ b/src/main/java/com/glodblock/github/inventory/ItemBiggerAppEngInventory.java
@@ -2,10 +2,10 @@ package com.glodblock.github.inventory;
 
 import net.minecraft.item.ItemStack;
 
+import com.glodblock.github.inventory.gui.GuiType;
+
 import appeng.tile.inventory.BiggerAppEngInventory;
 import appeng.util.Platform;
-
-import com.glodblock.github.inventory.gui.GuiType;
 
 public class ItemBiggerAppEngInventory extends BiggerAppEngInventory {
 

--- a/src/main/java/com/glodblock/github/inventory/WirelessFluidPatternTerminalPatterns.java
+++ b/src/main/java/com/glodblock/github/inventory/WirelessFluidPatternTerminalPatterns.java
@@ -2,11 +2,11 @@ package com.glodblock.github.inventory;
 
 import net.minecraft.item.ItemStack;
 
+import com.glodblock.github.inventory.item.IWirelessPatternTerminal;
+
 import appeng.tile.inventory.AppEngInternalInventory;
 import appeng.tile.inventory.InvOperation;
 import appeng.util.Platform;
-
-import com.glodblock.github.inventory.item.IWirelessPatternTerminal;
 
 public class WirelessFluidPatternTerminalPatterns extends AppEngInternalInventory {
 

--- a/src/main/java/com/glodblock/github/inventory/external/AEFluidInterfaceHandler.java
+++ b/src/main/java/com/glodblock/github/inventory/external/AEFluidInterfaceHandler.java
@@ -3,13 +3,13 @@ package com.glodblock.github.inventory.external;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.glodblock.github.util.Util;
+
 import appeng.api.implementations.tiles.ITileStorageMonitorable;
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.storage.IExternalStorageHandler;
 import appeng.api.storage.IMEInventory;
 import appeng.api.storage.StorageChannel;
-
-import com.glodblock.github.util.Util;
 
 public class AEFluidInterfaceHandler implements IExternalStorageHandler {
 

--- a/src/main/java/com/glodblock/github/inventory/external/AEFluidTankHandler.java
+++ b/src/main/java/com/glodblock/github/inventory/external/AEFluidTankHandler.java
@@ -4,12 +4,12 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.IFluidHandler;
 
+import com.glodblock.github.inventory.MEMonitorIFluidHandler;
+
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.storage.IExternalStorageHandler;
 import appeng.api.storage.IMEInventory;
 import appeng.api.storage.StorageChannel;
-
-import com.glodblock.github.inventory.MEMonitorIFluidHandler;
 
 // This handler is too generic, so it will overlap other mods' fluid handler.
 // It will be injected into external handler by ASM to make sure it is executed at last.

--- a/src/main/java/com/glodblock/github/inventory/gui/GuiType.java
+++ b/src/main/java/com/glodblock/github/inventory/gui/GuiType.java
@@ -6,13 +6,6 @@ import javax.annotation.Nullable;
 
 import net.minecraft.entity.player.EntityPlayer;
 
-import appeng.api.storage.ITerminalHost;
-import appeng.container.implementations.ContainerCraftAmount;
-import appeng.container.implementations.ContainerCraftingStatus;
-import appeng.container.implementations.ContainerPriority;
-import appeng.helpers.IInterfaceHost;
-import appeng.helpers.IPriorityHost;
-
 import com.glodblock.github.client.gui.*;
 import com.glodblock.github.client.gui.container.*;
 import com.glodblock.github.common.parts.PartFluidLevelEmitter;
@@ -24,6 +17,13 @@ import com.glodblock.github.inventory.IDualHost;
 import com.glodblock.github.inventory.item.IFluidPortableCell;
 import com.glodblock.github.inventory.item.IWirelessTerminal;
 import com.google.common.collect.ImmutableList;
+
+import appeng.api.storage.ITerminalHost;
+import appeng.container.implementations.ContainerCraftAmount;
+import appeng.container.implementations.ContainerCraftingStatus;
+import appeng.container.implementations.ContainerPriority;
+import appeng.helpers.IInterfaceHost;
+import appeng.helpers.IPriorityHost;
 
 public enum GuiType {
 

--- a/src/main/java/com/glodblock/github/inventory/gui/ItemGuiFactory.java
+++ b/src/main/java/com/glodblock/github/inventory/gui/ItemGuiFactory.java
@@ -8,11 +8,11 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.container.AEBaseContainer;
-import appeng.container.ContainerOpenContext;
-
 import com.glodblock.github.inventory.item.IItemInventory;
 import com.glodblock.github.util.Util;
+
+import appeng.container.AEBaseContainer;
+import appeng.container.ContainerOpenContext;
 
 public abstract class ItemGuiFactory<T> implements IGuiFactory {
 

--- a/src/main/java/com/glodblock/github/inventory/gui/PartOrItemGuiFactory.java
+++ b/src/main/java/com/glodblock/github/inventory/gui/PartOrItemGuiFactory.java
@@ -9,11 +9,11 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
-import appeng.container.AEBaseContainer;
-import appeng.container.ContainerOpenContext;
-
 import com.glodblock.github.inventory.item.IItemInventory;
 import com.glodblock.github.util.Util;
+
+import appeng.container.AEBaseContainer;
+import appeng.container.ContainerOpenContext;
 
 public abstract class PartOrItemGuiFactory<T> extends PartGuiFactory<T> {
 

--- a/src/main/java/com/glodblock/github/inventory/gui/TankMouseHandler.java
+++ b/src/main/java/com/glodblock/github/inventory/gui/TankMouseHandler.java
@@ -9,10 +9,10 @@ import net.minecraft.client.resources.I18n;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.api.storage.data.IAEFluidStack;
-
 import com.glodblock.github.inventory.IAEFluidTank;
 import com.glodblock.github.util.NameConst;
+
+import appeng.api.storage.data.IAEFluidStack;
 
 public class TankMouseHandler implements MouseRegionManager.Handler {
 

--- a/src/main/java/com/glodblock/github/inventory/item/IWirelessTerminal.java
+++ b/src/main/java/com/glodblock/github/inventory/item/IWirelessTerminal.java
@@ -2,13 +2,13 @@ package com.glodblock.github.inventory.item;
 
 import net.minecraft.item.ItemStack;
 
+import com.glodblock.github.common.item.ItemWirelessUltraTerminal;
+
 import appeng.api.implementations.guiobjects.IGuiItemObject;
 import appeng.api.implementations.tiles.IViewCellStorage;
 import appeng.api.networking.IGridHost;
 import appeng.api.networking.security.IActionHost;
 import appeng.tile.inventory.IAEAppEngInventory;
-
-import com.glodblock.github.common.item.ItemWirelessUltraTerminal;
 
 public interface IWirelessTerminal
         extends IFluidPortableCell, IViewCellStorage, IAEAppEngInventory, IGridHost, IActionHost {

--- a/src/main/java/com/glodblock/github/inventory/item/PortableFluidCellInventory.java
+++ b/src/main/java/com/glodblock/github/inventory/item/PortableFluidCellInventory.java
@@ -5,6 +5,8 @@ import java.util.Objects;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
+import com.glodblock.github.common.storage.FluidCellInventory;
+
 import appeng.api.config.*;
 import appeng.api.implementations.items.IAEItemPowerStorage;
 import appeng.api.storage.IMEMonitor;
@@ -14,8 +16,6 @@ import appeng.api.storage.data.IAEItemStack;
 import appeng.api.util.IConfigManager;
 import appeng.util.ConfigManager;
 import appeng.util.Platform;
-
-import com.glodblock.github.common.storage.FluidCellInventory;
 
 public class PortableFluidCellInventory extends MEMonitorHandler<IAEFluidStack> implements IFluidPortableCell {
 

--- a/src/main/java/com/glodblock/github/inventory/item/WirelessCraftingTerminalInventory.java
+++ b/src/main/java/com/glodblock/github/inventory/item/WirelessCraftingTerminalInventory.java
@@ -8,6 +8,9 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.glodblock.github.inventory.ItemBiggerAppEngInventory;
+import com.glodblock.github.util.Util;
+
 import appeng.api.config.*;
 import appeng.api.implementations.items.IAEItemPowerStorage;
 import appeng.api.networking.IGridNode;
@@ -25,9 +28,6 @@ import appeng.tile.inventory.AppEngInternalInventory;
 import appeng.tile.inventory.InvOperation;
 import appeng.util.ConfigManager;
 import appeng.util.Platform;
-
-import com.glodblock.github.inventory.ItemBiggerAppEngInventory;
-import com.glodblock.github.util.Util;
 
 public class WirelessCraftingTerminalInventory extends MEMonitorHandler<IAEItemStack>
         implements IWirelessCraftTerminal {

--- a/src/main/java/com/glodblock/github/inventory/item/WirelessFluidTerminalInventory.java
+++ b/src/main/java/com/glodblock/github/inventory/item/WirelessFluidTerminalInventory.java
@@ -8,6 +8,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.glodblock.github.util.Util;
+
 import appeng.api.config.*;
 import appeng.api.implementations.items.IAEItemPowerStorage;
 import appeng.api.networking.IGridNode;
@@ -25,8 +27,6 @@ import appeng.tile.inventory.AppEngInternalInventory;
 import appeng.tile.inventory.InvOperation;
 import appeng.util.ConfigManager;
 import appeng.util.Platform;
-
-import com.glodblock.github.util.Util;
 
 public class WirelessFluidTerminalInventory extends MEMonitorHandler<IAEFluidStack> implements IWirelessTerminal {
 

--- a/src/main/java/com/glodblock/github/inventory/item/WirelessInterfaceTerminalInventory.java
+++ b/src/main/java/com/glodblock/github/inventory/item/WirelessInterfaceTerminalInventory.java
@@ -8,6 +8,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.glodblock.github.util.Util;
+
 import appeng.api.config.*;
 import appeng.api.implementations.items.IAEItemPowerStorage;
 import appeng.api.networking.IGridNode;
@@ -21,8 +23,6 @@ import appeng.items.tools.powered.ToolWirelessTerminal;
 import appeng.tile.inventory.InvOperation;
 import appeng.util.ConfigManager;
 import appeng.util.Platform;
-
-import com.glodblock.github.util.Util;
 
 public class WirelessInterfaceTerminalInventory implements IWirelessInterfaceTerminal {
 

--- a/src/main/java/com/glodblock/github/inventory/item/WirelessPatternTerminalExInventory.java
+++ b/src/main/java/com/glodblock/github/inventory/item/WirelessPatternTerminalExInventory.java
@@ -10,6 +10,12 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.glodblock.github.common.item.ItemFluidDrop;
+import com.glodblock.github.common.item.ItemFluidPacket;
+import com.glodblock.github.inventory.ItemBiggerAppEngInventory;
+import com.glodblock.github.inventory.WirelessFluidPatternTerminalPatterns;
+import com.glodblock.github.util.Util;
+
 import appeng.api.config.*;
 import appeng.api.implementations.ICraftingPatternItem;
 import appeng.api.implementations.items.IAEItemPowerStorage;
@@ -29,12 +35,6 @@ import appeng.tile.inventory.AppEngInternalInventory;
 import appeng.tile.inventory.InvOperation;
 import appeng.util.ConfigManager;
 import appeng.util.Platform;
-
-import com.glodblock.github.common.item.ItemFluidDrop;
-import com.glodblock.github.common.item.ItemFluidPacket;
-import com.glodblock.github.inventory.ItemBiggerAppEngInventory;
-import com.glodblock.github.inventory.WirelessFluidPatternTerminalPatterns;
-import com.glodblock.github.util.Util;
 
 public class WirelessPatternTerminalExInventory extends MEMonitorHandler<IAEItemStack>
         implements IWirelessPatternTerminal {

--- a/src/main/java/com/glodblock/github/inventory/item/WirelessPatternTerminalInventory.java
+++ b/src/main/java/com/glodblock/github/inventory/item/WirelessPatternTerminalInventory.java
@@ -10,6 +10,12 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.glodblock.github.common.item.ItemFluidDrop;
+import com.glodblock.github.common.item.ItemFluidPacket;
+import com.glodblock.github.inventory.ItemBiggerAppEngInventory;
+import com.glodblock.github.inventory.WirelessFluidPatternTerminalPatterns;
+import com.glodblock.github.util.Util;
+
 import appeng.api.config.*;
 import appeng.api.implementations.ICraftingPatternItem;
 import appeng.api.implementations.items.IAEItemPowerStorage;
@@ -29,12 +35,6 @@ import appeng.tile.inventory.AppEngInternalInventory;
 import appeng.tile.inventory.InvOperation;
 import appeng.util.ConfigManager;
 import appeng.util.Platform;
-
-import com.glodblock.github.common.item.ItemFluidDrop;
-import com.glodblock.github.common.item.ItemFluidPacket;
-import com.glodblock.github.inventory.ItemBiggerAppEngInventory;
-import com.glodblock.github.inventory.WirelessFluidPatternTerminalPatterns;
-import com.glodblock.github.util.Util;
 
 public class WirelessPatternTerminalInventory extends MEMonitorHandler<IAEItemStack>
         implements IWirelessPatternTerminal {

--- a/src/main/java/com/glodblock/github/inventory/slot/OptionalFluidSlotFakeTypeOnly.java
+++ b/src/main/java/com/glodblock/github/inventory/slot/OptionalFluidSlotFakeTypeOnly.java
@@ -4,13 +4,13 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
-import appeng.container.slot.IOptionalSlotHost;
-import appeng.container.slot.OptionalSlotFakeTypeOnly;
-import appeng.util.item.AEFluidStack;
-
 import com.glodblock.github.common.item.ItemFluidPacket;
 import com.glodblock.github.inventory.AEFluidInventory;
 import com.glodblock.github.util.Util;
+
+import appeng.container.slot.IOptionalSlotHost;
+import appeng.container.slot.OptionalSlotFakeTypeOnly;
+import appeng.util.item.AEFluidStack;
 
 public class OptionalFluidSlotFakeTypeOnly extends OptionalSlotFakeTypeOnly {
 

--- a/src/main/java/com/glodblock/github/inventory/slot/SlotFluidConvertingFake.java
+++ b/src/main/java/com/glodblock/github/inventory/slot/SlotFluidConvertingFake.java
@@ -7,13 +7,13 @@ import net.minecraftforge.fluids.FluidContainerRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.IFluidContainerItem;
 
-import appeng.api.storage.data.IAEItemStack;
-import appeng.container.slot.SlotFake;
-import appeng.util.item.AEItemStack;
-
 import com.glodblock.github.common.item.ItemFluidPacket;
 import com.glodblock.github.inventory.AeItemStackHandler;
 import com.glodblock.github.inventory.AeStackInventory;
+
+import appeng.api.storage.data.IAEItemStack;
+import appeng.container.slot.SlotFake;
+import appeng.util.item.AEItemStack;
 
 public class SlotFluidConvertingFake extends SlotFake implements ISlotFluid {
 

--- a/src/main/java/com/glodblock/github/loader/CalculatorV2PluginLoader.java
+++ b/src/main/java/com/glodblock/github/loader/CalculatorV2PluginLoader.java
@@ -1,11 +1,11 @@
 package com.glodblock.github.loader;
 
+import com.glodblock.github.common.item.ItemFluidDrop;
+
 import appeng.api.storage.data.IAEItemStack;
 import appeng.crafting.v2.CraftingCalculations;
 import appeng.crafting.v2.CraftingRequest;
 import appeng.util.Platform;
-
-import com.glodblock.github.common.item.ItemFluidDrop;
 
 public class CalculatorV2PluginLoader {
 

--- a/src/main/java/com/glodblock/github/loader/ChannelLoader.java
+++ b/src/main/java/com/glodblock/github/loader/ChannelLoader.java
@@ -6,6 +6,7 @@ import net.minecraft.world.World;
 
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.network.*;
+
 import cpw.mods.fml.relauncher.Side;
 
 public class ChannelLoader implements Runnable {

--- a/src/main/java/com/glodblock/github/loader/filter/FluidFilter.java
+++ b/src/main/java/com/glodblock/github/loader/filter/FluidFilter.java
@@ -4,12 +4,12 @@ import static appeng.api.config.TypeFilter.*;
 
 import net.minecraft.item.Item;
 
+import com.glodblock.github.common.item.ItemFluidDrop;
+
 import appeng.api.config.TypeFilter;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IAEStack;
 import appeng.client.me.ItemRepo;
-
-import com.glodblock.github.common.item.ItemFluidDrop;
 
 public class FluidFilter {
 

--- a/src/main/java/com/glodblock/github/loader/recipe/WirelessTerminalRecipe.java
+++ b/src/main/java/com/glodblock/github/loader/recipe/WirelessTerminalRecipe.java
@@ -12,9 +12,9 @@ import net.minecraft.world.World;
 import net.p455w0rd.wirelesscraftingterminal.items.ItemEnum;
 import net.p455w0rd.wirelesscraftingterminal.items.ItemInfinityBooster;
 
-import appeng.util.Platform;
-
 import com.glodblock.github.common.item.ItemBaseWirelessTerminal;
+
+import appeng.util.Platform;
 
 public class WirelessTerminalRecipe extends ShapelessRecipes {
 

--- a/src/main/java/com/glodblock/github/nei/FluidCraftingTransferHandler.java
+++ b/src/main/java/com/glodblock/github/nei/FluidCraftingTransferHandler.java
@@ -10,6 +10,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 
+import com.glodblock.github.client.gui.GuiFluidCraftingWireless;
+
 import appeng.container.slot.SlotCraftingMatrix;
 import appeng.container.slot.SlotFakeCraftingMatrix;
 import appeng.core.sync.network.NetworkHandler;
@@ -18,8 +20,6 @@ import appeng.util.Platform;
 import codechicken.nei.PositionedStack;
 import codechicken.nei.api.IOverlayHandler;
 import codechicken.nei.recipe.IRecipeHandler;
-
-import com.glodblock.github.client.gui.GuiFluidCraftingWireless;
 
 public class FluidCraftingTransferHandler implements IOverlayHandler {
 

--- a/src/main/java/com/glodblock/github/nei/FluidPatternTerminalRecipeTransferHandler.java
+++ b/src/main/java/com/glodblock/github/nei/FluidPatternTerminalRecipeTransferHandler.java
@@ -5,15 +5,15 @@ import java.util.List;
 
 import net.minecraft.client.gui.inventory.GuiContainer;
 
-import codechicken.nei.api.IOverlayHandler;
-import codechicken.nei.recipe.IRecipeHandler;
-import codechicken.nei.recipe.TemplateRecipeHandler;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.client.gui.base.FCGuiEncodeTerminal;
 import com.glodblock.github.nei.object.OrderStack;
 import com.glodblock.github.nei.recipes.FluidRecipe;
 import com.glodblock.github.network.CPacketTransferRecipe;
+
+import codechicken.nei.api.IOverlayHandler;
+import codechicken.nei.recipe.IRecipeHandler;
+import codechicken.nei.recipe.TemplateRecipeHandler;
 
 public class FluidPatternTerminalRecipeTransferHandler implements IOverlayHandler {
 

--- a/src/main/java/com/glodblock/github/nei/NEIGuiHandler.java
+++ b/src/main/java/com/glodblock/github/nei/NEIGuiHandler.java
@@ -2,10 +2,10 @@ package com.glodblock.github.nei;
 
 import net.minecraft.client.gui.inventory.GuiContainer;
 
-import codechicken.nei.api.INEIGuiAdapter;
-
 import com.glodblock.github.client.gui.GuiFluidMonitor;
 import com.glodblock.github.client.gui.GuiItemMonitor;
+
+import codechicken.nei.api.INEIGuiAdapter;
 
 public class NEIGuiHandler extends INEIGuiAdapter {
 

--- a/src/main/java/com/glodblock/github/nei/NEIItemFilter.java
+++ b/src/main/java/com/glodblock/github/nei/NEIItemFilter.java
@@ -4,16 +4,16 @@ import java.util.regex.Pattern;
 
 import net.minecraft.item.ItemStack;
 
+import com.glodblock.github.common.storage.IFluidCellInventory;
+import com.glodblock.github.common.storage.IFluidCellInventoryHandler;
+import com.glodblock.github.common.storage.IStorageFluidCell;
+
 import appeng.api.AEApi;
 import appeng.api.storage.IMEInventoryHandler;
 import appeng.api.storage.StorageChannel;
 import appeng.api.storage.data.IAEFluidStack;
 import codechicken.nei.SearchField;
 import codechicken.nei.api.ItemFilter;
-
-import com.glodblock.github.common.storage.IFluidCellInventory;
-import com.glodblock.github.common.storage.IFluidCellInventoryHandler;
-import com.glodblock.github.common.storage.IStorageFluidCell;
 
 public class NEIItemFilter implements SearchField.ISearchProvider {
 

--- a/src/main/java/com/glodblock/github/nei/NEI_FC_Config.java
+++ b/src/main/java/com/glodblock/github/nei/NEI_FC_Config.java
@@ -1,12 +1,12 @@
 package com.glodblock.github.nei;
 
-import codechicken.nei.api.API;
-import codechicken.nei.api.IConfigureNEI;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.client.gui.*;
 import com.glodblock.github.nei.recipes.FluidRecipe;
 import com.glodblock.github.util.ModAndClassUtil;
+
+import codechicken.nei.api.API;
+import codechicken.nei.api.IConfigureNEI;
 
 public class NEI_FC_Config implements IConfigureNEI {
 

--- a/src/main/java/com/glodblock/github/nei/object/OrderStack.java
+++ b/src/main/java/com/glodblock/github/nei/object/OrderStack.java
@@ -12,9 +12,9 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.oredict.OreDictionary;
 
-import codechicken.nei.PositionedStack;
-
 import com.glodblock.github.util.Util;
+
+import codechicken.nei.PositionedStack;
 
 public class OrderStack<T> {
 

--- a/src/main/java/com/glodblock/github/nei/recipes/FluidRecipe.java
+++ b/src/main/java/com/glodblock/github/nei/recipes/FluidRecipe.java
@@ -6,13 +6,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
-import codechicken.nei.PositionedStack;
-import codechicken.nei.recipe.IRecipeHandler;
-import codechicken.nei.recipe.TemplateRecipeHandler;
-
 import com.glodblock.github.nei.object.IRecipeExtractor;
 import com.glodblock.github.nei.object.IRecipeExtractorLegacy;
 import com.glodblock.github.nei.object.OrderStack;
+
+import codechicken.nei.PositionedStack;
+import codechicken.nei.recipe.IRecipeHandler;
+import codechicken.nei.recipe.TemplateRecipeHandler;
 
 public final class FluidRecipe {
 

--- a/src/main/java/com/glodblock/github/nei/recipes/extractor/AvaritiaRecipeExtractor.java
+++ b/src/main/java/com/glodblock/github/nei/recipes/extractor/AvaritiaRecipeExtractor.java
@@ -2,12 +2,12 @@ package com.glodblock.github.nei.recipes.extractor;
 
 import java.util.List;
 
-import codechicken.nei.PositionedStack;
-import codechicken.nei.recipe.IRecipeHandler;
-
 import com.glodblock.github.nei.NEIUtils;
 import com.glodblock.github.nei.object.IRecipeExtractor;
 import com.glodblock.github.nei.object.OrderStack;
+
+import codechicken.nei.PositionedStack;
+import codechicken.nei.recipe.IRecipeHandler;
 
 public class AvaritiaRecipeExtractor implements IRecipeExtractor {
 

--- a/src/main/java/com/glodblock/github/nei/recipes/extractor/EnderIORecipeExtractor.java
+++ b/src/main/java/com/glodblock/github/nei/recipes/extractor/EnderIORecipeExtractor.java
@@ -7,14 +7,13 @@ import java.util.List;
 
 import net.minecraftforge.fluids.FluidStack;
 
-import codechicken.nei.PositionedStack;
-import codechicken.nei.recipe.IRecipeHandler;
-import codechicken.nei.recipe.TemplateRecipeHandler;
-
 import com.glodblock.github.nei.object.IRecipeExtractor;
 import com.glodblock.github.nei.object.OrderStack;
 import com.glodblock.github.util.Ae2Reflect;
 
+import codechicken.nei.PositionedStack;
+import codechicken.nei.recipe.IRecipeHandler;
+import codechicken.nei.recipe.TemplateRecipeHandler;
 import crazypants.enderio.machine.crusher.CrusherRecipeManager;
 import crazypants.enderio.nei.VatRecipeHandler;
 

--- a/src/main/java/com/glodblock/github/nei/recipes/extractor/ExtractorUtil.java
+++ b/src/main/java/com/glodblock/github/nei/recipes/extractor/ExtractorUtil.java
@@ -6,9 +6,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import codechicken.nei.PositionedStack;
-
 import com.glodblock.github.nei.object.OrderStack;
+
+import codechicken.nei.PositionedStack;
 
 public final class ExtractorUtil {
 

--- a/src/main/java/com/glodblock/github/nei/recipes/extractor/ForestryRecipeExtractor.java
+++ b/src/main/java/com/glodblock/github/nei/recipes/extractor/ForestryRecipeExtractor.java
@@ -5,13 +5,12 @@ import java.util.List;
 
 import net.minecraftforge.fluids.FluidStack;
 
-import codechicken.nei.PositionedStack;
-import codechicken.nei.recipe.IRecipeHandler;
-import codechicken.nei.recipe.TemplateRecipeHandler;
-
 import com.glodblock.github.nei.object.IRecipeExtractorLegacy;
 import com.glodblock.github.nei.object.OrderStack;
 
+import codechicken.nei.PositionedStack;
+import codechicken.nei.recipe.IRecipeHandler;
+import codechicken.nei.recipe.TemplateRecipeHandler;
 import forestry.core.recipes.nei.PositionedFluidTank;
 import forestry.core.recipes.nei.RecipeHandlerBase;
 import forestry.factory.recipes.nei.NEIHandlerFabricator;

--- a/src/main/java/com/glodblock/github/nei/recipes/extractor/GregTech5RecipeExtractor.java
+++ b/src/main/java/com/glodblock/github/nei/recipes/extractor/GregTech5RecipeExtractor.java
@@ -7,11 +7,10 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
-import codechicken.nei.PositionedStack;
-
 import com.glodblock.github.nei.object.IRecipeExtractor;
 import com.glodblock.github.nei.object.OrderStack;
 
+import codechicken.nei.PositionedStack;
 import gregtech.api.enums.ItemList;
 import gregtech.common.items.GT_FluidDisplayItem;
 

--- a/src/main/java/com/glodblock/github/nei/recipes/extractor/GregTech6RecipeExtractor.java
+++ b/src/main/java/com/glodblock/github/nei/recipes/extractor/GregTech6RecipeExtractor.java
@@ -5,11 +5,10 @@ import java.util.List;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
-import codechicken.nei.PositionedStack;
-
 import com.glodblock.github.nei.object.IRecipeExtractor;
 import com.glodblock.github.nei.object.OrderStack;
 
+import codechicken.nei.PositionedStack;
 import gregapi.item.ItemFluidDisplay;
 import gregapi.recipes.Recipe;
 

--- a/src/main/java/com/glodblock/github/nei/recipes/extractor/IndustrialCraftRecipeExtractor.java
+++ b/src/main/java/com/glodblock/github/nei/recipes/extractor/IndustrialCraftRecipeExtractor.java
@@ -10,13 +10,12 @@ import java.util.stream.Collectors;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
-import codechicken.nei.PositionedStack;
-import codechicken.nei.recipe.IRecipeHandler;
-
 import com.glodblock.github.nei.object.IRecipeExtractor;
 import com.glodblock.github.nei.object.OrderStack;
 import com.glodblock.github.util.Ae2Reflect;
 
+import codechicken.nei.PositionedStack;
+import codechicken.nei.recipe.IRecipeHandler;
 import ic2.neiIntegration.core.recipehandler.FluidCannerRecipeHandler;
 import ic2.neiIntegration.core.recipehandler.OreWashingRecipeHandler;
 

--- a/src/main/java/com/glodblock/github/nei/recipes/extractor/VanillaRecipeExtractor.java
+++ b/src/main/java/com/glodblock/github/nei/recipes/extractor/VanillaRecipeExtractor.java
@@ -3,10 +3,10 @@ package com.glodblock.github.nei.recipes.extractor;
 import java.util.LinkedList;
 import java.util.List;
 
-import codechicken.nei.PositionedStack;
-
 import com.glodblock.github.nei.object.IRecipeExtractor;
 import com.glodblock.github.nei.object.OrderStack;
+
+import codechicken.nei.PositionedStack;
 
 public class VanillaRecipeExtractor implements IRecipeExtractor {
 

--- a/src/main/java/com/glodblock/github/network/CPacketCraftRequest.java
+++ b/src/main/java/com/glodblock/github/network/CPacketCraftRequest.java
@@ -9,6 +9,11 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import com.glodblock.github.inventory.InventoryHandler;
+import com.glodblock.github.inventory.gui.GuiType;
+import com.glodblock.github.inventory.item.IWirelessTerminal;
+import com.glodblock.github.util.BlockPos;
+
 import appeng.api.networking.IGrid;
 import appeng.api.networking.IGridHost;
 import appeng.api.networking.IGridNode;
@@ -18,12 +23,6 @@ import appeng.container.ContainerOpenContext;
 import appeng.container.implementations.ContainerCraftAmount;
 import appeng.container.implementations.ContainerCraftConfirm;
 import appeng.core.AELog;
-
-import com.glodblock.github.inventory.InventoryHandler;
-import com.glodblock.github.inventory.gui.GuiType;
-import com.glodblock.github.inventory.item.IWirelessTerminal;
-import com.glodblock.github.util.BlockPos;
-
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;

--- a/src/main/java/com/glodblock/github/network/CPacketFluidUpdate.java
+++ b/src/main/java/com/glodblock/github/network/CPacketFluidUpdate.java
@@ -9,12 +9,11 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.item.ItemStack;
 
-import appeng.api.storage.data.IAEFluidStack;
-import appeng.util.item.AEItemStack;
-
 import com.glodblock.github.client.gui.container.ContainerFluidMonitor;
 import com.glodblock.github.util.Util;
 
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.util.item.AEItemStack;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;

--- a/src/main/java/com/glodblock/github/network/CPacketInventoryAction.java
+++ b/src/main/java/com/glodblock/github/network/CPacketInventoryAction.java
@@ -10,13 +10,6 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 
-import appeng.api.storage.data.IAEItemStack;
-import appeng.container.AEBaseContainer;
-import appeng.container.ContainerOpenContext;
-import appeng.container.implementations.ContainerCraftAmount;
-import appeng.helpers.InventoryAction;
-import appeng.util.item.AEItemStack;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.client.gui.container.ContainerPatternValueAmount;
 import com.glodblock.github.common.item.ItemFluidPacket;
@@ -26,6 +19,12 @@ import com.glodblock.github.inventory.item.IWirelessTerminal;
 import com.glodblock.github.util.BlockPos;
 import com.glodblock.github.util.Util;
 
+import appeng.api.storage.data.IAEItemStack;
+import appeng.container.AEBaseContainer;
+import appeng.container.ContainerOpenContext;
+import appeng.container.implementations.ContainerCraftAmount;
+import appeng.helpers.InventoryAction;
+import appeng.util.item.AEItemStack;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;

--- a/src/main/java/com/glodblock/github/network/CPacketLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/network/CPacketLevelMaintainer.java
@@ -9,12 +9,11 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
-import appeng.api.storage.data.IAEItemStack;
-import appeng.util.item.AEItemStack;
-
 import com.glodblock.github.client.gui.container.ContainerLevelMaintainer;
 import com.glodblock.github.common.tile.TileLevelMaintainer;
 
+import appeng.api.storage.data.IAEItemStack;
+import appeng.util.item.AEItemStack;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;

--- a/src/main/java/com/glodblock/github/network/CPacketPatternValueSet.java
+++ b/src/main/java/com/glodblock/github/network/CPacketPatternValueSet.java
@@ -8,10 +8,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.fluids.FluidStack;
 
-import appeng.api.networking.IGridHost;
-import appeng.container.ContainerOpenContext;
-import appeng.container.slot.SlotFake;
-
 import com.glodblock.github.client.gui.container.ContainerPatternValueAmount;
 import com.glodblock.github.client.gui.container.base.FCContainerEncodeTerminal;
 import com.glodblock.github.common.item.ItemFluidPacket;
@@ -22,6 +18,9 @@ import com.glodblock.github.inventory.item.IWirelessTerminal;
 import com.glodblock.github.util.BlockPos;
 import com.glodblock.github.util.Util;
 
+import appeng.api.networking.IGridHost;
+import appeng.container.ContainerOpenContext;
+import appeng.container.slot.SlotFake;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;

--- a/src/main/java/com/glodblock/github/network/CPacketRenamer.java
+++ b/src/main/java/com/glodblock/github/network/CPacketRenamer.java
@@ -7,10 +7,6 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import appeng.container.AEBaseContainer;
-import appeng.helpers.ICustomNameObject;
-import appeng.tile.networking.TileCableBus;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.inventory.InventoryHandler;
 import com.glodblock.github.inventory.gui.GuiType;
@@ -18,6 +14,9 @@ import com.glodblock.github.inventory.item.IWirelessInterfaceTerminal;
 import com.glodblock.github.util.BlockPos;
 import com.glodblock.github.util.Util;
 
+import appeng.container.AEBaseContainer;
+import appeng.helpers.ICustomNameObject;
+import appeng.tile.networking.TileCableBus;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;

--- a/src/main/java/com/glodblock/github/network/CPacketSwitchGuis.java
+++ b/src/main/java/com/glodblock/github/network/CPacketSwitchGuis.java
@@ -8,9 +8,6 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.Container;
 import net.minecraft.tileentity.TileEntity;
 
-import appeng.container.AEBaseContainer;
-import appeng.container.ContainerOpenContext;
-
 import com.glodblock.github.common.item.ItemWirelessUltraTerminal;
 import com.glodblock.github.inventory.InventoryHandler;
 import com.glodblock.github.inventory.gui.GuiType;
@@ -18,6 +15,8 @@ import com.glodblock.github.inventory.item.IWirelessTerminal;
 import com.glodblock.github.util.BlockPos;
 import com.glodblock.github.util.Util;
 
+import appeng.container.AEBaseContainer;
+import appeng.container.ContainerOpenContext;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;

--- a/src/main/java/com/glodblock/github/network/CPacketTransferRecipe.java
+++ b/src/main/java/com/glodblock/github/network/CPacketTransferRecipe.java
@@ -11,17 +11,16 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.fluids.FluidStack;
 
-import appeng.api.AEApi;
-import appeng.api.storage.IMEMonitor;
-import appeng.api.storage.data.IAEItemStack;
-import appeng.api.storage.data.IItemList;
-
 import com.glodblock.github.client.gui.container.ContainerItemMonitor;
 import com.glodblock.github.client.gui.container.base.FCContainerEncodeTerminal;
 import com.glodblock.github.common.item.ItemFluidPacket;
 import com.glodblock.github.nei.NEIUtils;
 import com.glodblock.github.nei.object.OrderStack;
 
+import appeng.api.AEApi;
+import appeng.api.storage.IMEMonitor;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.api.storage.data.IItemList;
 import cpw.mods.fml.common.network.ByteBufUtils;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;

--- a/src/main/java/com/glodblock/github/network/SPacketFluidUpdate.java
+++ b/src/main/java/com/glodblock/github/network/SPacketFluidUpdate.java
@@ -8,13 +8,12 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.item.ItemStack;
 
-import appeng.api.storage.data.IAEFluidStack;
-import appeng.api.storage.data.IAEItemStack;
-import appeng.util.item.AEItemStack;
-
 import com.glodblock.github.client.gui.*;
 import com.glodblock.github.util.Util;
 
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.util.item.AEItemStack;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;

--- a/src/main/java/com/glodblock/github/network/SPacketMEFluidInvUpdate.java
+++ b/src/main/java/com/glodblock/github/network/SPacketMEFluidInvUpdate.java
@@ -7,12 +7,11 @@ import java.util.List;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 
-import appeng.api.storage.data.IAEFluidStack;
-import appeng.util.item.AEFluidStack;
-
 import com.glodblock.github.client.gui.GuiFluidCraftConfirm;
 import com.glodblock.github.client.gui.GuiFluidMonitor;
 
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.util.item.AEFluidStack;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;

--- a/src/main/java/com/glodblock/github/network/SPacketMEItemInvUpdate.java
+++ b/src/main/java/com/glodblock/github/network/SPacketMEItemInvUpdate.java
@@ -7,13 +7,12 @@ import java.util.List;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 
-import appeng.api.storage.data.IAEItemStack;
-import appeng.util.item.AEItemStack;
-
 import com.glodblock.github.client.gui.GuiFluidCraftConfirm;
 import com.glodblock.github.client.gui.GuiItemMonitor;
 import com.glodblock.github.client.gui.GuiLevelMaintainer;
 
+import appeng.api.storage.data.IAEItemStack;
+import appeng.util.item.AEItemStack;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;

--- a/src/main/java/com/glodblock/github/network/SPacketMEUpdateBuffer.java
+++ b/src/main/java/com/glodblock/github/network/SPacketMEUpdateBuffer.java
@@ -8,12 +8,11 @@ import java.util.concurrent.TimeUnit;
 
 import net.minecraft.entity.player.EntityPlayerMP;
 
-import appeng.api.storage.data.IAEFluidStack;
-import appeng.api.storage.data.IAEItemStack;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.common.Config;
 
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.api.storage.data.IAEItemStack;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent;
 

--- a/src/main/java/com/glodblock/github/proxy/CommonProxy.java
+++ b/src/main/java/com/glodblock/github/proxy/CommonProxy.java
@@ -31,12 +31,12 @@ public class CommonProxy {
     public void init(FMLInitializationEvent event) {
         this.registerMovables();
         FMLCommonHandler.instance().bus().register(SPacketMEUpdateBuffer.class);
-        if (!ModAndClassUtil.EC2 && Config.replaceEC2) {
-            EC2Replacer.initReplacer();
-        }
     }
 
     public void postInit(FMLPostInitializationEvent event) {
+        if (!ModAndClassUtil.EC2 && Config.replaceEC2) {
+            EC2Replacer.initReplacer();
+        }
         if (ModAndClassUtil.isBigInterface) {
             Upgrades.PATTERN_CAPACITY.registerItem(new ItemStack(ItemAndBlockHolder.FLUID_INTERFACE), 3);
             Upgrades.PATTERN_CAPACITY.registerItem(new ItemStack(ItemAndBlockHolder.INTERFACE), 3);

--- a/src/main/java/com/glodblock/github/proxy/CommonProxy.java
+++ b/src/main/java/com/glodblock/github/proxy/CommonProxy.java
@@ -2,10 +2,6 @@ package com.glodblock.github.proxy;
 
 import net.minecraft.item.ItemStack;
 
-import appeng.api.AEApi;
-import appeng.api.IAppEngApi;
-import appeng.api.config.Upgrades;
-
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.common.Config;
 import com.glodblock.github.common.tile.TileWalrus;
@@ -15,6 +11,9 @@ import com.glodblock.github.loader.ItemAndBlockHolder;
 import com.glodblock.github.network.SPacketMEUpdateBuffer;
 import com.glodblock.github.util.ModAndClassUtil;
 
+import appeng.api.AEApi;
+import appeng.api.IAppEngApi;
+import appeng.api.config.Upgrades;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;

--- a/src/main/java/com/glodblock/github/util/DualityFluidInterface.java
+++ b/src/main/java/com/glodblock/github/util/DualityFluidInterface.java
@@ -11,6 +11,12 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidHandler;
 
+import com.glodblock.github.common.item.ItemFluidPacket;
+import com.glodblock.github.inventory.AEFluidInventory;
+import com.glodblock.github.inventory.IAEFluidInventory;
+import com.glodblock.github.inventory.IAEFluidTank;
+import com.glodblock.github.inventory.MEMonitorIFluidHandler;
+
 import appeng.api.config.Actionable;
 import appeng.api.config.Upgrades;
 import appeng.api.implementations.IUpgradeableHost;
@@ -41,12 +47,6 @@ import appeng.util.ConfigManager;
 import appeng.util.IConfigManagerHost;
 import appeng.util.Platform;
 import appeng.util.item.AEFluidStack;
-
-import com.glodblock.github.common.item.ItemFluidPacket;
-import com.glodblock.github.inventory.AEFluidInventory;
-import com.glodblock.github.inventory.IAEFluidInventory;
-import com.glodblock.github.inventory.IAEFluidTank;
-import com.glodblock.github.inventory.MEMonitorIFluidHandler;
 
 public class DualityFluidInterface implements IGridTickable, IStorageMonitorable, IAEFluidInventory, IUpgradeableHost,
         IConfigManagerHost, IFluidHandler {

--- a/src/main/java/com/glodblock/github/util/FluidSorters.java
+++ b/src/main/java/com/glodblock/github/util/FluidSorters.java
@@ -4,14 +4,14 @@ import java.util.Comparator;
 
 import net.minecraftforge.fluids.Fluid;
 
+import com.glodblock.github.common.item.ItemFluidDrop;
+
 import appeng.api.config.SortDir;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.integration.IntegrationRegistry;
 import appeng.integration.IntegrationType;
 import appeng.integration.abstraction.IInvTweaks;
 import appeng.util.Platform;
-
-import com.glodblock.github.common.item.ItemFluidDrop;
 
 public class FluidSorters {
 

--- a/src/main/java/com/glodblock/github/util/Util.java
+++ b/src/main/java/com/glodblock/github/util/Util.java
@@ -19,6 +19,13 @@ import net.minecraftforge.fluids.*;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.MutablePair;
 
+import com.glodblock.github.common.item.ItemBaseWirelessTerminal;
+import com.glodblock.github.common.item.ItemFluidDrop;
+import com.glodblock.github.common.item.ItemFluidPacket;
+import com.glodblock.github.common.item.ItemWirelessUltraTerminal;
+import com.glodblock.github.inventory.IAEFluidTank;
+import com.glodblock.github.inventory.item.IFluidPortableCell;
+
 import appeng.api.AEApi;
 import appeng.api.config.Actionable;
 import appeng.api.config.PowerMultiplier;
@@ -43,14 +50,6 @@ import appeng.tile.networking.TileWireless;
 import appeng.util.Platform;
 import appeng.util.item.AEFluidStack;
 import baubles.api.BaublesApi;
-
-import com.glodblock.github.common.item.ItemBaseWirelessTerminal;
-import com.glodblock.github.common.item.ItemFluidDrop;
-import com.glodblock.github.common.item.ItemFluidPacket;
-import com.glodblock.github.common.item.ItemWirelessUltraTerminal;
-import com.glodblock.github.inventory.IAEFluidTank;
-import com.glodblock.github.inventory.item.IFluidPortableCell;
-
 import cpw.mods.fml.common.ModContainer;
 import cpw.mods.fml.common.registry.GameData;
 import io.netty.buffer.ByteBuf;


### PR DESCRIPTION
Continuing from the previous remapping PR https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/115
* Updates buildscript (because it'll get squashed anyways...)
* Adds support for OpenComputers modules
* Ore dict bus now converts to export bus + ore dict card w/ settings retained
* Wireless now has proper NBT mappings