### PR TITLE
Update APIs

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -16,7 +16,7 @@ dependencies {
     compileOnly('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
     compileOnly('com.gregoriust.gregtech:gregtech_1.7.10:6.14.23:dev') { transitive = false }
     compileOnly('com.github.GTNewHorizons:OpenComputers:1.9.5-GTNH:dev') { transitive = false }
-    compileOnly('com.github.GTNewHorizons:ThaumicEnergistics:1.4.1-GTNH:dev') { transitive = false }
+    compileOnly('com.github.GTNewHorizons:ThaumicEnergistics:1.4.2-GTNH:dev') { transitive = false }
     compileOnly('com.github.GTNewHorizons:GTplusplus:1.9.4:dev') { transitive = false }
     compileOnly("com.github.GTNewHorizons:Hodgepodge:2.2.10:dev") { transitive = false }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@
 
 dependencies {
     api('com.github.GTNewHorizons:NotEnoughItems:2.3.50-GTNH:dev')
-    api('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-208-GTNH:dev')
+    api('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-215-GTNH:dev')
     api('curse.maven:cofh-core-69162:2388751')
     api('com.github.GTNewHorizons:waila:1.6.0:dev')
     api('com.github.GTNewHorizons:Baubles:1.0.1.16:dev')

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,7 @@ gradleTokenGroupName = GRADLETOKEN_GROUPNAME
 # In case your mod provides an API for other mods to implement you may declare its package here. Otherwise, you can
 # leave this property empty.
 # Example value: apiPackage = api + modGroup = com.myname.mymodid -> com.myname.mymodid.api
-apiPackage =
+apiPackage = api
 
 # Specify the configuration file for Forge's access transformers here. I must be placed into /src/main/resources/META-INF/
 # Example value: mymodid_at.cfg

--- a/src/main/java/com/glodblock/github/FluidCraft.java
+++ b/src/main/java/com/glodblock/github/FluidCraft.java
@@ -77,7 +77,7 @@ public class FluidCraft {
             CalculatorV2PluginLoader.installCalculatorV2Plugins();
         }
         if (ModAndClassUtil.isTypeFilter) {
-            FluidFilter.installFilter();
+            AEApi.instance().registries().itemDisplay().addItemFilter(FluidFilter::filter);
         }
 
         proxy.postInit(event);

--- a/src/main/java/com/glodblock/github/api/FluidCraftAPI.java
+++ b/src/main/java/com/glodblock/github/api/FluidCraftAPI.java
@@ -1,0 +1,45 @@
+package com.glodblock.github.api;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import net.minecraftforge.fluids.Fluid;
+
+public final class FluidCraftAPI implements IFluidCraftAPI {
+
+    private static final FluidCraftAPI API = new FluidCraftAPI();
+
+    /**
+     * These fluids will not be allowed to be stored in fluid storage cells.
+     */
+    private final Set<Class<? extends Fluid>> blacklistedFluids = new HashSet<>();
+
+    /**
+     * These fluids will not be displayed in a fluid terminal.
+     */
+    private final Set<Class<? extends Fluid>> blacklistedDispFluids = new HashSet<>();
+
+    public static FluidCraftAPI instance() {
+        return API;
+    }
+
+    @Override
+    public void blacklistFluidInStorage(Class<? extends Fluid> fluid) {
+        blacklistedFluids.add(fluid);
+    }
+
+    @Override
+    public void blacklistFluidInDisplay(Class<? extends Fluid> fluid) {
+        blacklistedDispFluids.add(fluid);
+    }
+
+    @Override
+    public boolean isBlacklistedInStorage(Class<? extends Fluid> fluid) {
+        return blacklistedFluids.contains(fluid);
+    }
+
+    @Override
+    public boolean isBlacklistedInDisplay(Class<? extends Fluid> fluid) {
+        return blacklistedDispFluids.contains(fluid);
+    }
+}

--- a/src/main/java/com/glodblock/github/api/IFluidCraftAPI.java
+++ b/src/main/java/com/glodblock/github/api/IFluidCraftAPI.java
@@ -1,0 +1,27 @@
+package com.glodblock.github.api;
+
+import net.minecraftforge.fluids.Fluid;
+
+@SuppressWarnings("unused")
+public interface IFluidCraftAPI {
+
+    /**
+     * Blacklisted fluids will not be allowed to be added to a storage cell.
+     */
+    void blacklistFluidInStorage(Class<? extends Fluid> fluid);
+
+    /**
+     * Blacklisted fluids will not be displayed in fluid terminals.
+     */
+    void blacklistFluidInDisplay(Class<? extends Fluid> fluid);
+
+    /**
+     * Mostly for internal use; queries whether the fluid is blacklisted from storage cells.
+     */
+    boolean isBlacklistedInStorage(Class<? extends Fluid> fluid);
+
+    /**
+     * Mostly for internal use; queries whether the fluid is blacklisted from being displayed.
+     */
+    boolean isBlacklistedInDisplay(Class<? extends Fluid> fluid);
+}

--- a/src/main/java/com/glodblock/github/client/gui/base/FCGuiMonitor.java
+++ b/src/main/java/com/glodblock/github/client/gui/base/FCGuiMonitor.java
@@ -29,11 +29,11 @@ import appeng.api.implementations.tiles.IViewCellStorage;
 import appeng.api.storage.ITerminalHost;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IAEStack;
+import appeng.api.storage.data.IDisplayRepo;
 import appeng.api.util.IConfigManager;
 import appeng.api.util.IConfigurableObject;
 import appeng.client.gui.widgets.*;
 import appeng.client.me.InternalSlotME;
-import appeng.client.me.ItemRepo;
 import appeng.client.me.SlotDisconnected;
 import appeng.client.me.SlotME;
 import appeng.container.AEBaseContainer;
@@ -67,7 +67,7 @@ public abstract class FCGuiMonitor<T extends IAEStack<T>> extends FCBaseMEGui
     protected final ItemStack[] myCurrentViewCells = new ItemStack[5];
     public FCContainerMonitor<T> monitorableContainer;
     public GuiTabButton craftingStatusBtn;
-    protected ItemRepo repo;
+    protected IDisplayRepo repo;
     protected GuiImgButton craftingStatusImgBtn;
     protected FCGuiTextField searchField;
     protected int perRow = 9;
@@ -649,7 +649,7 @@ public abstract class FCGuiMonitor<T extends IAEStack<T>> extends FCBaseMEGui
 
     @Override
     public void updateScreen() {
-        this.repo.setPower(this.monitorableContainer.isPowered());
+        this.repo.setPowered(this.monitorableContainer.isPowered());
         super.updateScreen();
     }
 

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerEssentiaMonitor.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerEssentiaMonitor.java
@@ -119,12 +119,6 @@ public class ContainerEssentiaMonitor extends ContainerFluidPortableCell {
                     if (slotIndex == -1) {
                         out.stackSize = fluidContainer.stackSize;
                     } else {
-                        if (drainStack != null) {
-                            System.out.print("---------\n");
-                            System.out.print(drainStack.right + "\n");
-                            System.out.print(drainStack.left + "\n");
-                            System.out.print(aeFluidStack.getStackSize() + "\n");
-                        }
                         out.stackSize = (int) (fluidContainer.stackSize
                                 - (aeFluidStack.getStackSize() / drainStack.left));
                     }

--- a/src/main/java/com/glodblock/github/client/me/EssentiaRepo.java
+++ b/src/main/java/com/glodblock/github/client/me/EssentiaRepo.java
@@ -1,17 +1,25 @@
 package com.glodblock.github.client.me;
 
 import java.util.Iterator;
+import java.util.regex.Pattern;
 
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 
 import com.glodblock.github.common.item.ItemFluidDrop;
 import com.glodblock.github.crossmod.thaumcraft.AspectUtil;
+import com.glodblock.github.util.FluidSorters;
 
+import appeng.api.config.SearchBoxMode;
+import appeng.api.config.Settings;
+import appeng.api.config.SortOrder;
+import appeng.api.config.ViewItems;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.client.gui.widgets.IScrollSource;
 import appeng.client.gui.widgets.ISortSource;
+import appeng.core.AEConfig;
 
 public class EssentiaRepo extends FluidRepo {
 
@@ -21,7 +29,84 @@ public class EssentiaRepo extends FluidRepo {
 
     @Override
     public void updateView() {
-        super.updateView();
+        this.view.clear();
+        this.dsp.clear();
+
+        this.view.ensureCapacity(this.list.size());
+        this.dsp.ensureCapacity(this.list.size());
+
+        final Enum<?> viewMode = this.sortSrc.getSortDisplay();
+        final Enum<?> searchMode = AEConfig.instance.settings.getSetting(Settings.SEARCH_MODE);
+        if (searchMode == SearchBoxMode.NEI_AUTOSEARCH || searchMode == SearchBoxMode.NEI_MANUAL_SEARCH) {
+            this.updateNEI(this.searchString);
+        }
+
+        String innerSearch = this.searchString;
+
+        if (innerSearch.startsWith("@")) {
+            innerSearch = innerSearch.substring(1);
+        }
+
+        Pattern m;
+        try {
+            m = Pattern.compile(innerSearch.toLowerCase(), Pattern.CASE_INSENSITIVE);
+        } catch (final Throwable ignore) {
+            try {
+                m = Pattern.compile(Pattern.quote(innerSearch.toLowerCase()), Pattern.CASE_INSENSITIVE);
+            } catch (final Throwable __) {
+                return;
+            }
+        }
+
+        for (IAEItemStack is : this.list) {
+            if (this.myPartitionList != null) {
+                if (!this.myPartitionList.isListed(is)) {
+                    continue;
+                }
+            }
+
+            if (viewMode == ViewItems.CRAFTABLE && !is.isCraftable()) {
+                continue;
+            }
+
+            if (viewMode == ViewItems.CRAFTABLE) {
+                is = is.copy();
+                is.setStackSize(0);
+            }
+
+            if (viewMode == ViewItems.STORED && is.getStackSize() == 0) {
+                continue;
+            }
+
+            Fluid fluid = ItemFluidDrop.getAeFluidStack(is).getFluid();
+            if (!AspectUtil.isEssentiaGas(fluid)) {
+                continue;
+            }
+
+            if (m.matcher(fluid.getLocalizedName().toLowerCase()).find()) {
+                this.view.add(is);
+            }
+        }
+
+        final Enum<?> SortBy = this.sortSrc.getSortBy();
+        final Enum<?> SortDir = this.sortSrc.getSortDir();
+
+        FluidSorters.setDirection((appeng.api.config.SortDir) SortDir);
+        FluidSorters.init();
+
+        if (SortBy == SortOrder.MOD) {
+            this.view.sort(FluidSorters.CONFIG_BASED_SORT_BY_MOD);
+        } else if (SortBy == SortOrder.AMOUNT) {
+            this.view.sort(FluidSorters.CONFIG_BASED_SORT_BY_SIZE);
+        } else if (SortBy == SortOrder.INVTWEAKS) {
+            this.view.sort(FluidSorters.CONFIG_BASED_SORT_BY_INV_TWEAKS);
+        } else {
+            this.view.sort(FluidSorters.CONFIG_BASED_SORT_BY_NAME);
+        }
+
+        for (final IAEItemStack is : this.view) {
+            this.dsp.add(is.getItemStack());
+        }
         Iterator<IAEItemStack> it1 = this.view.iterator();
         while (it1.hasNext()) {
             IAEFluidStack fluid = ItemFluidDrop.getAeFluidStack(it1.next());

--- a/src/main/java/com/glodblock/github/client/me/FluidRepo.java
+++ b/src/main/java/com/glodblock/github/client/me/FluidRepo.java
@@ -20,6 +20,7 @@ import javax.annotation.Nonnull;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
 
+import com.glodblock.github.api.FluidCraftAPI;
 import com.glodblock.github.common.item.ItemFluidDrop;
 import com.glodblock.github.util.FluidSorters;
 import com.glodblock.github.util.Util;
@@ -145,7 +146,13 @@ public class FluidRepo extends ItemRepo {
             if (viewMode == ViewItems.STORED && is.getStackSize() == 0) {
                 continue;
             }
+
             Fluid fluid = ItemFluidDrop.getAeFluidStack(is).getFluid();
+
+            if (FluidCraftAPI.instance().isBlacklistedInDisplay(fluid.getClass())) {
+                continue;
+            }
+
             if (searchMod) {
                 if (m.matcher(Util.getFluidModID(fluid).toLowerCase()).find()
                         || m.matcher(Util.getFluidModName(fluid).toLowerCase()).find()) {

--- a/src/main/java/com/glodblock/github/client/me/FluidRepo.java
+++ b/src/main/java/com/glodblock/github/client/me/FluidRepo.java
@@ -28,36 +28,36 @@ import com.glodblock.github.util.Util;
 import appeng.api.AEApi;
 import appeng.api.config.*;
 import appeng.api.storage.data.IAEItemStack;
+import appeng.api.storage.data.IDisplayRepo;
 import appeng.api.storage.data.IItemList;
 import appeng.client.gui.widgets.IScrollSource;
 import appeng.client.gui.widgets.ISortSource;
-import appeng.client.me.ItemRepo;
 import appeng.core.AEConfig;
 import appeng.items.storage.ItemViewCell;
 import appeng.util.prioitylist.IPartitionList;
 import cpw.mods.fml.relauncher.ReflectionHelper;
 
-public class FluidRepo extends ItemRepo {
+public class FluidRepo implements IDisplayRepo {
 
-    private final IItemList<IAEItemStack> list = AEApi.instance().storage().createItemList();
+    protected final IItemList<IAEItemStack> list = AEApi.instance().storage().createItemList();
     protected final ArrayList<IAEItemStack> view = new ArrayList<>();
     protected final ArrayList<ItemStack> dsp = new ArrayList<>();
-    private final IScrollSource src;
-    private final ISortSource sortSrc;
+    protected final IScrollSource src;
+    protected final ISortSource sortSrc;
 
-    private int rowSize = 9;
+    protected int rowSize = 9;
 
-    private String searchString = "";
-    private IPartitionList<IAEItemStack> myPartitionList;
+    protected String searchString = "";
+    protected IPartitionList<IAEItemStack> myPartitionList;
     private String NEIWord = null;
     private boolean hasPower;
 
     public FluidRepo(final IScrollSource src, final ISortSource sortSrc) {
-        super(src, sortSrc);
         this.src = src;
         this.sortSrc = sortSrc;
     }
 
+    @Override
     public IAEItemStack getReferenceItem(int idx) {
         idx += this.src.getCurrentScroll() * this.rowSize;
 
@@ -67,6 +67,7 @@ public class FluidRepo extends ItemRepo {
         return this.view.get(idx);
     }
 
+    @Override
     public ItemStack getItem(int idx) {
         idx += this.src.getCurrentScroll() * this.rowSize;
 
@@ -76,10 +77,7 @@ public class FluidRepo extends ItemRepo {
         return this.dsp.get(idx);
     }
 
-    void setSearch(final String search) {
-        this.searchString = search == null ? "" : search;
-    }
-
+    @Override
     public void postUpdate(final IAEItemStack is) {
         final IAEItemStack st = this.list.findPrecise(is);
         if (st != null) {
@@ -90,11 +88,13 @@ public class FluidRepo extends ItemRepo {
         }
     }
 
+    @Override
     public void setViewCell(final ItemStack[] list) {
         this.myPartitionList = ItemViewCell.createFilter(list);
         this.updateView();
     }
 
+    @Override
     public void updateView() {
         this.view.clear();
         this.dsp.clear();
@@ -186,7 +186,7 @@ public class FluidRepo extends ItemRepo {
         }
     }
 
-    private void updateNEI(final String filter) {
+    protected void updateNEI(final String filter) {
         try {
             if (this.NEIWord == null || !this.NEIWord.equals(filter)) {
                 final Class<?> c = ReflectionHelper
@@ -206,19 +206,23 @@ public class FluidRepo extends ItemRepo {
         }
     }
 
+    @Override
     public int size() {
         return this.view.size();
     }
 
+    @Override
     public void clear() {
         this.list.resetStatus();
     }
 
+    @Override
     public boolean hasPower() {
         return this.hasPower;
     }
 
-    public void setPower(final boolean hasPower) {
+    @Override
+    public void setPowered(final boolean hasPower) {
         this.hasPower = hasPower;
     }
 

--- a/src/main/java/com/glodblock/github/common/Config.java
+++ b/src/main/java/com/glodblock/github/common/Config.java
@@ -15,7 +15,6 @@ public class Config {
     public static boolean noFluidPacket;
     public static boolean fluidIOBus;
     public static boolean removeRecipe;
-    public static boolean blacklistEssentiaGas;
     public static double portableCellBattery;
     public static int packetSize;
     public static int packetRate;
@@ -47,11 +46,6 @@ public class Config {
                 "Fluid Craft for AE2",
                 false,
                 "Disable all recipes, for quick tweaker.");
-        blacklistEssentiaGas = Config.getBoolean(
-                "Blacklist Essentia Gas",
-                "Fluid Craft for AE2",
-                true,
-                "Blacklist Essentia Gas from Thaumic Energistics, so they won't be stored in Fluid Storage Cells.");
         portableCellBattery = Config.get("Fluid Craft for AE2", "Portable Fluid Cell Battery Capacity", 20000D)
                 .getDouble();
         packetSize = Config.get("Fluid Craft for AE2", "packetSize", 256, "Number of items to be sent per packet")
@@ -62,8 +56,8 @@ public class Config {
                 .getInt();
         if (packetRate <= 0) packetRate = 50;
         replaceEC2 = Config.getBoolean(
-                "Fluid Craft for AE2",
                 "replaceEC2",
+                "Fluid Craft for AE2",
                 true,
                 "Set true to handle missing item mappings from EC2. Note to work properly, you must have all relevant parts.");
         if (Config.hasChanged()) Config.save();

--- a/src/main/java/com/glodblock/github/common/item/FCBaseItemCell.java
+++ b/src/main/java/com/glodblock/github/common/item/FCBaseItemCell.java
@@ -14,13 +14,12 @@ import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import com.glodblock.github.common.Config;
+import com.glodblock.github.api.FluidCraftAPI;
 import com.glodblock.github.common.storage.CellType;
 import com.glodblock.github.common.storage.IFluidCellInventory;
 import com.glodblock.github.common.storage.IFluidCellInventoryHandler;
 import com.glodblock.github.common.storage.IStorageFluidCell;
 import com.glodblock.github.loader.ItemAndBlockHolder;
-import com.glodblock.github.util.ModAndClassUtil;
 import com.glodblock.github.util.NameConst;
 import com.google.common.base.Optional;
 
@@ -87,10 +86,13 @@ public abstract class FCBaseItemCell extends AEBaseItem implements IStorageFluid
 
     @Override
     public boolean isBlackListed(ItemStack cellItem, IAEFluidStack requestedAddition) {
-        if (Config.blacklistEssentiaGas && ModAndClassUtil.ThE && requestedAddition != null) {
-            return ModAndClassUtil.essentiaGas.isInstance(requestedAddition.getFluid());
-        }
-        return false;
+        // if (Config.blacklistEssentiaGas && ModAndClassUtil.ThE && requestedAddition != null) {
+        // return ModAndClassUtil.essentiaGas.isInstance(requestedAddition.getFluid());
+        // }
+        //
+        // What even is a null fluid
+        return requestedAddition == null || requestedAddition.getFluid() == null
+                || FluidCraftAPI.instance().isBlacklistedInStorage(requestedAddition.getFluid().getClass());
     }
 
     @Override

--- a/src/main/java/com/glodblock/github/common/item/ItemCreativeFluidStorageCell.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemCreativeFluidStorageCell.java
@@ -10,13 +10,12 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
 
 import com.glodblock.github.FluidCraft;
-import com.glodblock.github.common.Config;
+import com.glodblock.github.api.FluidCraftAPI;
 import com.glodblock.github.common.storage.IFluidCellInventory;
 import com.glodblock.github.common.storage.IFluidCellInventoryHandler;
 import com.glodblock.github.common.storage.IStorageFluidCell;
 import com.glodblock.github.common.tabs.FluidCraftingTabs;
 import com.glodblock.github.loader.IRegister;
-import com.glodblock.github.util.ModAndClassUtil;
 import com.glodblock.github.util.NameConst;
 
 import appeng.api.AEApi;
@@ -54,10 +53,9 @@ public class ItemCreativeFluidStorageCell extends AEBaseItem
 
     @Override
     public boolean isBlackListed(ItemStack cellItem, IAEFluidStack requestedAddition) {
-        if (Config.blacklistEssentiaGas && ModAndClassUtil.ThE && requestedAddition != null) {
-            return ModAndClassUtil.essentiaGas.isInstance(requestedAddition.getFluid());
-        }
-        return false;
+        // What even is a null fluid
+        return requestedAddition == null || requestedAddition.getFluid() == null
+                || FluidCraftAPI.instance().isBlacklistedInStorage(requestedAddition.getFluid().getClass());
     }
 
     @Override

--- a/src/main/java/com/glodblock/github/common/item/ItemPortableFluidCell.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemPortableFluidCell.java
@@ -13,6 +13,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import com.glodblock.github.FluidCraft;
+import com.glodblock.github.api.FluidCraftAPI;
 import com.glodblock.github.common.Config;
 import com.glodblock.github.common.storage.IFluidCellInventory;
 import com.glodblock.github.common.storage.IFluidCellInventoryHandler;
@@ -24,7 +25,6 @@ import com.glodblock.github.inventory.item.IItemInventory;
 import com.glodblock.github.inventory.item.PortableFluidCellInventory;
 import com.glodblock.github.loader.IRegister;
 import com.glodblock.github.util.BlockPos;
-import com.glodblock.github.util.ModAndClassUtil;
 import com.glodblock.github.util.NameConst;
 import com.glodblock.github.util.RenderUtil;
 import com.google.common.base.Optional;
@@ -132,10 +132,9 @@ public class ItemPortableFluidCell extends AEBasePoweredItem
 
     @Override
     public boolean isBlackListed(ItemStack cellItem, IAEFluidStack requestedAddition) {
-        if (Config.blacklistEssentiaGas && ModAndClassUtil.ThE && requestedAddition != null) {
-            return ModAndClassUtil.essentiaGas.isInstance(requestedAddition.getFluid());
-        }
-        return false;
+        // What even is a null fluid
+        return requestedAddition == null || requestedAddition.getFluid() == null
+                || FluidCraftAPI.instance().isBlacklistedInStorage(requestedAddition.getFluid().getClass());
     }
 
     @Override

--- a/src/main/java/com/glodblock/github/common/tile/TileFluidDiscretizer.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileFluidDiscretizer.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import com.glodblock.github.api.FluidCraftAPI;
 import com.glodblock.github.common.item.ItemFluidDrop;
 
 import appeng.api.AEApi;
@@ -190,7 +191,7 @@ public class TileFluidDiscretizer extends AENetworkTile implements IPriorityHost
                 if (fluidGrid != null) {
                     for (IAEFluidStack fluid : fluidGrid.getStorageList()) {
                         IAEItemStack stack = ItemFluidDrop.newAeStack(fluid);
-                        if (stack != null) {
+                        if (stack != null && !FluidCraftAPI.instance().isBlacklistedInDisplay(fluid.getFluid().getClass())) {
                             itemCache.add(stack);
                         }
                     }
@@ -221,7 +222,7 @@ public class TileFluidDiscretizer extends AENetworkTile implements IPriorityHost
                 List<IAEItemStack> mappedChanges = new ArrayList<>();
                 for (IAEFluidStack fluidStack : change) {
                     IAEItemStack itemStack = ItemFluidDrop.newAeStack(fluidStack);
-                    if (itemStack != null) {
+                    if (itemStack != null && !FluidCraftAPI.instance().isBlacklistedInDisplay(fluidStack.getFluid().getClass())) {
                         mappedChanges.add(itemStack);
                     }
                 }

--- a/src/main/java/com/glodblock/github/common/tile/TileFluidDiscretizer.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileFluidDiscretizer.java
@@ -191,7 +191,8 @@ public class TileFluidDiscretizer extends AENetworkTile implements IPriorityHost
                 if (fluidGrid != null) {
                     for (IAEFluidStack fluid : fluidGrid.getStorageList()) {
                         IAEItemStack stack = ItemFluidDrop.newAeStack(fluid);
-                        if (stack != null && !FluidCraftAPI.instance().isBlacklistedInDisplay(fluid.getFluid().getClass())) {
+                        if (stack != null
+                                && !FluidCraftAPI.instance().isBlacklistedInDisplay(fluid.getFluid().getClass())) {
                             itemCache.add(stack);
                         }
                     }
@@ -222,7 +223,8 @@ public class TileFluidDiscretizer extends AENetworkTile implements IPriorityHost
                 List<IAEItemStack> mappedChanges = new ArrayList<>();
                 for (IAEFluidStack fluidStack : change) {
                     IAEItemStack itemStack = ItemFluidDrop.newAeStack(fluidStack);
-                    if (itemStack != null && !FluidCraftAPI.instance().isBlacklistedInDisplay(fluidStack.getFluid().getClass())) {
+                    if (itemStack != null
+                            && !FluidCraftAPI.instance().isBlacklistedInDisplay(fluidStack.getFluid().getClass())) {
                         mappedChanges.add(itemStack);
                     }
                 }

--- a/src/main/java/com/glodblock/github/crossmod/extracells/storage/ProxyFluidStorageCell.java
+++ b/src/main/java/com/glodblock/github/crossmod/extracells/storage/ProxyFluidStorageCell.java
@@ -3,10 +3,9 @@ package com.glodblock.github.crossmod.extracells.storage;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 
-import com.glodblock.github.common.Config;
+import com.glodblock.github.api.FluidCraftAPI;
 import com.glodblock.github.common.storage.IStorageFluidCell;
 import com.glodblock.github.crossmod.extracells.ProxyItem;
-import com.glodblock.github.util.ModAndClassUtil;
 
 import appeng.api.config.FuzzyMode;
 import appeng.api.storage.data.IAEFluidStack;
@@ -46,10 +45,9 @@ public class ProxyFluidStorageCell extends ProxyItem implements IStorageFluidCel
 
     @Override
     public boolean isBlackListed(ItemStack cellItem, IAEFluidStack requestedAddition) {
-        if (Config.blacklistEssentiaGas && ModAndClassUtil.ThE && requestedAddition != null) {
-            return ModAndClassUtil.essentiaGas.isInstance(requestedAddition.getFluid());
-        }
-        return false;
+        // What even is a null fluid
+        return requestedAddition == null || requestedAddition.getFluid() == null
+                || FluidCraftAPI.instance().isBlacklistedInStorage(requestedAddition.getFluid().getClass());
     }
 
     @Override

--- a/src/main/java/com/glodblock/github/crossmod/thaumcraft/AspectUtil.java
+++ b/src/main/java/com/glodblock/github/crossmod/thaumcraft/AspectUtil.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -11,9 +12,11 @@ import org.apache.commons.lang3.tuple.MutablePair;
 
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.util.item.AEFluidStack;
+import cpw.mods.fml.common.Optional;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.IEssentiaContainerItem;
 import thaumcraft.common.Thaumcraft;
+import thaumicenergistics.api.ThEApi;
 import thaumicenergistics.api.storage.IAspectStack;
 import thaumicenergistics.common.fluids.GaseousEssentia;
 import thaumicenergistics.common.integration.tc.EssentiaItemContainerHelper;
@@ -22,13 +25,22 @@ import thaumicenergistics.common.storage.AspectStack;
 public class AspectUtil {
 
     public static final EssentiaItemContainerHelper HELPER = EssentiaItemContainerHelper.INSTANCE;
-    public static final int R = 128;
+    public static int R = 128;
+
+    @Optional.Method(modid = "thaumicenergistics")
+    public static void init() {
+        R = ThEApi.instance().config().conversionMultiplier();
+    }
 
     public static boolean isPlayerDiscoveredAspect(final EntityPlayer player, final Aspect aspect) {
         if (player != null && aspect != null) {
             return Thaumcraft.proxy.getPlayerKnowledge().hasDiscoveredAspect(player.getCommandSenderName(), aspect);
         }
         return false;
+    }
+
+    public static boolean isEssentiaGas(Fluid fluid) {
+        return fluid != null && fluid instanceof GaseousEssentia;
     }
 
     public static boolean isEssentiaGas(FluidStack fluid) {

--- a/src/main/java/com/glodblock/github/loader/filter/FluidFilter.java
+++ b/src/main/java/com/glodblock/github/loader/filter/FluidFilter.java
@@ -9,15 +9,10 @@ import com.glodblock.github.common.item.ItemFluidDrop;
 import appeng.api.config.TypeFilter;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IAEStack;
-import appeng.client.me.ItemRepo;
 
 public class FluidFilter {
 
-    public static void installFilter() {
-        ItemRepo.registerTypeHandler(FluidFilter::filter, FLUIDS);
-    }
-
-    private static boolean filter(IAEStack<?> stack, TypeFilter typeFilter) {
+    public static boolean filter(TypeFilter typeFilter, IAEStack<?> stack) {
         if (typeFilter == ALL) return true;
         if (stack instanceof IAEItemStack) {
             Item item = ((IAEItemStack) stack).getItem();

--- a/src/main/java/com/glodblock/github/proxy/CommonProxy.java
+++ b/src/main/java/com/glodblock/github/proxy/CommonProxy.java
@@ -3,7 +3,6 @@ package com.glodblock.github.proxy;
 import net.minecraft.item.ItemStack;
 
 import com.glodblock.github.FluidCraft;
-import com.glodblock.github.api.FluidCraftAPI;
 import com.glodblock.github.common.Config;
 import com.glodblock.github.common.tile.TileWalrus;
 import com.glodblock.github.crossmod.extracells.EC2Replacer;
@@ -22,7 +21,6 @@ import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.network.simpleimpl.SimpleNetworkWrapper;
-import thaumicenergistics.common.fluids.GaseousEssentia;
 
 public class CommonProxy {
 

--- a/src/main/java/com/glodblock/github/proxy/CommonProxy.java
+++ b/src/main/java/com/glodblock/github/proxy/CommonProxy.java
@@ -1,5 +1,6 @@
 package com.glodblock.github.proxy;
 
+import com.glodblock.github.api.FluidCraftAPI;
 import net.minecraft.item.ItemStack;
 
 import com.glodblock.github.FluidCraft;
@@ -20,6 +21,7 @@ import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.network.simpleimpl.SimpleNetworkWrapper;
+import thaumicenergistics.common.fluids.GaseousEssentia;
 
 public class CommonProxy {
 
@@ -58,6 +60,8 @@ public class CommonProxy {
             Upgrades.CRAFTING.registerItem(new ItemStack(ItemAndBlockHolder.FLUID_EXPORT_BUS), 1);
         }
         AEApi.instance().registries().externalStorage().addExternalStorageInterface(new AEFluidInterfaceHandler());
+        FluidCraftAPI.instance().blacklistFluidInStorage(GaseousEssentia.class);
+        FluidCraftAPI.instance().blacklistFluidInDisplay(GaseousEssentia.class);
     }
 
     public void registerRenderers() {}

--- a/src/main/java/com/glodblock/github/proxy/CommonProxy.java
+++ b/src/main/java/com/glodblock/github/proxy/CommonProxy.java
@@ -1,12 +1,13 @@
 package com.glodblock.github.proxy;
 
-import com.glodblock.github.api.FluidCraftAPI;
 import net.minecraft.item.ItemStack;
 
 import com.glodblock.github.FluidCraft;
+import com.glodblock.github.api.FluidCraftAPI;
 import com.glodblock.github.common.Config;
 import com.glodblock.github.common.tile.TileWalrus;
 import com.glodblock.github.crossmod.extracells.EC2Replacer;
+import com.glodblock.github.crossmod.thaumcraft.AspectUtil;
 import com.glodblock.github.inventory.external.AEFluidInterfaceHandler;
 import com.glodblock.github.loader.ItemAndBlockHolder;
 import com.glodblock.github.network.SPacketMEUpdateBuffer;
@@ -32,6 +33,9 @@ public class CommonProxy {
     public void init(FMLInitializationEvent event) {
         this.registerMovables();
         FMLCommonHandler.instance().bus().register(SPacketMEUpdateBuffer.class);
+        if (ModAndClassUtil.ThE) {
+            AspectUtil.init();
+        }
     }
 
     public void postInit(FMLPostInitializationEvent event) {
@@ -60,8 +64,6 @@ public class CommonProxy {
             Upgrades.CRAFTING.registerItem(new ItemStack(ItemAndBlockHolder.FLUID_EXPORT_BUS), 1);
         }
         AEApi.instance().registries().externalStorage().addExternalStorageInterface(new AEFluidInterfaceHandler());
-        FluidCraftAPI.instance().blacklistFluidInStorage(GaseousEssentia.class);
-        FluidCraftAPI.instance().blacklistFluidInDisplay(GaseousEssentia.class);
     }
 
     public void registerRenderers() {}

--- a/src/main/java/com/glodblock/github/util/ModAndClassUtil.java
+++ b/src/main/java/com/glodblock/github/util/ModAndClassUtil.java
@@ -113,10 +113,9 @@ public final class ModAndClassUtil {
             isV2 = false;
         }
         try {
-            Field filters = Class.forName("appeng.client.me.ItemRepo").getDeclaredField("filters");
-            if (filters == null) isTypeFilter = false;
+            Class<?> filter = Class.forName("appeng.core.features.registries.ItemDisplayRegistry");
             isTypeFilter = true;
-        } catch (ClassNotFoundException | NoSuchFieldException e) {
+        } catch (ClassNotFoundException e) {
             isTypeFilter = false;
         }
 

--- a/src/main/java/com/glodblock/github/util/ModAndClassUtil.java
+++ b/src/main/java/com/glodblock/github/util/ModAndClassUtil.java
@@ -40,8 +40,6 @@ public final class ModAndClassUtil {
 
     public static boolean isBeSubstitutionsButton;
 
-    public static Class<?> essentiaGas;
-
     @SuppressWarnings("all")
     public static void init() {
 
@@ -120,12 +118,6 @@ public final class ModAndClassUtil {
             isTypeFilter = true;
         } catch (ClassNotFoundException | NoSuchFieldException e) {
             isTypeFilter = false;
-        }
-
-        try {
-            essentiaGas = Class.forName("thaumicenergistics.common.fluids.GaseousEssentia");
-        } catch (ClassNotFoundException e) {
-            essentiaGas = null;
         }
 
         if (Loader.isModLoaded("gregtech") && !Loader.isModLoaded("gregapi")) GT5 = true;


### PR DESCRIPTION
* Removed Thaumic Energistics config setting: `blacklistEssentiaGas`. This will be handled by Thaumic Energistic's side (which also happens to have a config setting for this).

* Added an API that allows for blacklisting fluids from either the storage or the display individually.

* Use new AE APIs for handling type filters.
