### PR TITLE
Untangle Baubles hard dependency and skip on unmapped items/blocks

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,7 +5,7 @@ dependencies {
     api('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-215-GTNH:dev')
     api('curse.maven:cofh-core-69162:2388751')
     api('com.github.GTNewHorizons:waila:1.6.0:dev')
-    api('com.github.GTNewHorizons:Baubles:1.0.1.16:dev')
+    compileOnly('com.github.GTNewHorizons:Baubles:1.0.1.16:dev')
 
     compileOnly('com.github.GTNewHorizons:ExtraCells2:2.5.34:dev') { transitive = false }
     compileOnly("com.github.GTNewHorizons:WirelessCraftingTerminal:1.9.0:dev")

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@
 
 dependencies {
     api('com.github.GTNewHorizons:NotEnoughItems:2.3.50-GTNH:dev')
-    api('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-215-GTNH:dev')
+    api('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-234-GTNH:dev')
     api('curse.maven:cofh-core-69162:2388751')
     api('com.github.GTNewHorizons:waila:1.6.0:dev')
     compileOnly('com.github.GTNewHorizons:Baubles:1.0.1.16:dev')

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerDualInterface.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerDualInterface.java
@@ -13,7 +13,7 @@ import appeng.helpers.IInterfaceHost;
 
 public class ContainerDualInterface extends ContainerInterface {
 
-    @GuiSync(10)
+    @GuiSync(11)
     public SidelessMode sidelessMode;
 
     private final boolean isTile;

--- a/src/main/java/com/glodblock/github/common/item/ItemWirelessUltraTerminal.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemWirelessUltraTerminal.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 
-import cpw.mods.fml.common.Optional;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -37,6 +36,7 @@ import appeng.core.localization.PlayerMessages;
 import appeng.util.Platform;
 import baubles.api.BaubleType;
 import baubles.api.IBauble;
+import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;

--- a/src/main/java/com/glodblock/github/common/item/ItemWirelessUltraTerminal.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemWirelessUltraTerminal.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 
+import cpw.mods.fml.common.Optional;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -40,6 +41,7 @@ import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
+@Optional.Interface(iface = "baubles.api.IBauble", modid = "Baubles")
 public class ItemWirelessUltraTerminal extends ItemBaseWirelessTerminal
         implements IBauble, IRegister<ItemWirelessUltraTerminal> {
 

--- a/src/main/java/com/glodblock/github/crossmod/extracells/EC2Replacer.java
+++ b/src/main/java/com/glodblock/github/crossmod/extracells/EC2Replacer.java
@@ -24,8 +24,6 @@ public class EC2Replacer {
             if (m.type == GameRegistry.Type.ITEM && ItemReplacements.registry.containsKey(m.name)) {
                 Item toRemap = ItemReplacements.registry.get(m.name);
                 m.remap(toRemap);
-            } else {
-                m.warn();
             }
         }
     }


### PR DESCRIPTION
Have forge issue the standard "Missing items" screen when updating, so players are warned before joining the world. Previously we consumed all missing mapping by mistake.

Remove the hard dependency on baubles by adding Optional.Interface