### PR TITLE
Render drops as fluids in GuiCraftConfirm

### DIFF
--- a/src/main/java/com/glodblock/github/coremod/FCClassTransformer.java
+++ b/src/main/java/com/glodblock/github/coremod/FCClassTransformer.java
@@ -18,7 +18,7 @@ public class FCClassTransformer implements IClassTransformer {
             case "appeng.me.cluster.implementations.CraftingCPUCluster" -> tform = CraftingCpuTransformer.INSTANCE;
             case "appeng.helpers.DualityInterface" -> tform = DualityInterfaceTransformer.INSTANCE;
             case "appeng.container.implementations.ContainerInterfaceTerminal" -> tform = ContainerInterfaceTerminalTransformer.INSTANCE;
-            case "appeng.client.gui.implementations.GuiCraftingCPU", "appeng.client.gui.implementations.GuiCraftConfirm", "net.p455w0rd.wirelesscraftingterminal.client.gui.GuiCraftConfirm" -> tform = GuiCraftingTransformer.INSTANCE;
+            case "appeng.client.gui.implementations.GuiCraftingCPU", "appeng.client.gui.implementations.GuiCraftConfirm", "net.p455w0rd.wirelesscraftingterminal.client.gui.GuiCraftConfirm", "appeng.client.gui.widgets.GuiCraftingTree" -> tform = GuiCraftingTransformer.INSTANCE;
             case "appeng.integration.modules.NEI" -> tform = NEITransfermer.INSTANCE;
             case "appeng.core.features.registries.ExternalStorageRegistry" -> tform = ExternalStorageRegistryTransformer.INSTANCE;
             case "appeng.core.sync.packets.PacketCompressedNBT" -> tform = PacketCompressedNBTTransformer.INSTANCE;

--- a/src/main/java/com/glodblock/github/coremod/transform/GuiCraftingTransformer.java
+++ b/src/main/java/com/glodblock/github/coremod/transform/GuiCraftingTransformer.java
@@ -27,7 +27,7 @@ public class GuiCraftingTransformer extends FCClassTransformer.ClassMapper {
 
         @Override
         public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
-            if ("drawFG".equals(name)) {
+            if ("drawFG".equals(name) || "drawListFG".equals(name)) {
                 return new TransformFluidIcon(api, super.visitMethod(access, name, desc, signature, exceptions));
             }
             return super.visitMethod(access, name, desc, signature, exceptions);

--- a/src/main/java/com/glodblock/github/coremod/transform/GuiCraftingTransformer.java
+++ b/src/main/java/com/glodblock/github/coremod/transform/GuiCraftingTransformer.java
@@ -27,7 +27,7 @@ public class GuiCraftingTransformer extends FCClassTransformer.ClassMapper {
 
         @Override
         public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
-            if ("drawFG".equals(name) || "drawListFG".equals(name)) {
+            if ("drawFG".equals(name) || "drawListFG".equals(name) || "drawStack".equals(name)) {
                 return new TransformFluidIcon(api, super.visitMethod(access, name, desc, signature, exceptions));
             }
             return super.visitMethod(access, name, desc, signature, exceptions);


### PR DESCRIPTION
The crafting tree feature changed where the itemstacks were being drawn from `drawFG` to `drawListFG`. This changes the ASM to include that in its visit.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14035

Also adds the fluid icons to the crafting tree view

![image](https://github.com/GTNewHorizons/AE2FluidCraft-Rework/assets/49818773/baf42c08-1dce-468d-b6c3-c4aaf6a529d4)
