### PR TITLE
Add null check for retrieving tank info

### DIFF
--- a/src/main/java/com/glodblock/github/inventory/FluidConvertingInventoryAdaptor.java
+++ b/src/main/java/com/glodblock/github/inventory/FluidConvertingInventoryAdaptor.java
@@ -393,7 +393,10 @@ public class FluidConvertingInventoryAdaptor extends InventoryAdaptor {
                         if (p2p == invFluidsP2P || p2p == null) continue;
                         IFluidHandler target = Ae2Reflect.getP2PLiquidTarget(p2p);
                         if (target == null) continue;
-                        tankInfos.add(target.getTankInfo(p2p.getSide().getOpposite()));
+                        FluidTankInfo[] info = target.getTankInfo(p2p.getSide().getOpposite());
+                        if (info != null) {
+                            tankInfos.add(info);
+                        }
                     }
                 } catch (GridAccessException ignore) {}
             } else {


### PR DESCRIPTION
ThaumicTinkerer transvector interface can return null for sides (EIO does this as well). Normally this is handled when it is directly adjacent to the dual interface via a null check, but for p2ps it is not checked, leading to a NPE. Adds a check for it