### PR TITLE
Fix gt++ fluid cells not extracting properly

### DIFF
--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidMonitor.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidMonitor.java
@@ -306,7 +306,7 @@ public class ContainerFluidMonitor extends FCContainerMonitor<IAEFluidStack> {
             // Step 2: Find out how much fluid we can extract from the container. If this is null or 0, return.
             ItemStack test = fluidContainer.copy();
             test.stackSize = 1;
-            FluidStack fluidStack = fcItem.drain(test, 1, false);
+            FluidStack fluidStack = fcItem.drain(test, fluidPerContainer, false);
             if (fluidStack == null || fluidStack.amount == 0) {
                 return;
             }

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidMonitor.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidMonitor.java
@@ -325,8 +325,9 @@ public class ContainerFluidMonitor extends FCContainerMonitor<IAEFluidStack> {
             // 4.2: Handle empty output
             if (insertionResults[ACT_IDX] > 0) {
                 emptyStack = fluidContainer.copy();
-                emptyStack.stackSize = insertionResults[ACT_IDX];
+                emptyStack.stackSize = 1;
                 fcItem.drain(emptyStack, fluidPerContainer, true);
+                emptyStack.stackSize = insertionResults[ACT_IDX];
             }
         } else if (FluidContainerRegistry.isContainer(fluidContainer)) {
             // Step 1: Find out how much fluid we can insert.
@@ -424,7 +425,9 @@ public class ContainerFluidMonitor extends FCContainerMonitor<IAEFluidStack> {
     private void extractFluid(IAEFluidStack fluid, ItemStack fluidContainer, EntityPlayer player, int heldContainers) {
         // Step 1: Check if fluid can actually get filled into the fluidContainer
         if (fluidContainer.getItem() instanceof IFluidContainerItem fcItem) {
-            int test = fcItem.fill(fluidContainer, fluid.getFluidStack(), false);
+            ItemStack testStack = fluidContainer.copy();
+            testStack.stackSize = 1;
+            int test = fcItem.fill(testStack, fluid.getFluidStack(), false);
             if (test == 0) {
                 return;
             }


### PR DESCRIPTION
If GT++ fluid tank item sees a stacksize > 1, it refuses to fill/drain the tank item, so we need to set the stack size to 1 before performing tests. Otherwise we get dupes/incorrect behavior

Also fixes GT cells not working. They implement IContainerFluidItem instead of using FluidContainerRegistry.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14254