### PR TITLE
Increase maintainer digit limit to 16.

### DIFF
--- a/src/main/java/com/glodblock/github/client/gui/GuiLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiLevelMaintainer.java
@@ -538,7 +538,7 @@ public class GuiLevelMaintainer extends AEBaseGui implements INEIGuiHandler {
             this.textField = textField;
             this.textField.setEnableBackgroundDrawing(false);
             this.textField.setText("0");
-            this.textField.setMaxStringLength(10); // this length is enough to useful
+            this.textField.setMaxStringLength(16); // this length is enough to be useful
             this.idx = idx;
             this.action = action;
             this.tooltip = tooltip;


### PR DESCRIPTION
Current limit was actually not enough for end game GTNH. Increased to 16 digits which allows for maintaining up to single digit quadrillions (P). Let's hope this will be enough for the near future :)

![image](https://github.com/GTNewHorizons/AE2FluidCraft-Rework/assets/2588062/b2bc5889-4fa4-4717-b92f-b143e638c387)
