### PR TITLE
Optimize CPacketFluidUpdate

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1701530445
+//version: 1702141377
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -54,7 +54,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.13.0' apply false // 6.13.0 is the last jvm8 supporting version
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.24'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.26'
 }
 
 print("You might want to check out './gradlew :faq' if your build fails.\n")
@@ -613,7 +613,7 @@ repositories {
         }
         maven {
             name = "ic2"
-            url = getURL("https://maven.ic2.player.to/", "https://maven2.ic2.player.to/")
+            url = getURL("https://maven2.ic2.player.to/", "https://maven.ic2.player.to/")
             content {
                 includeGroup "net.industrial-craft"
             }
@@ -672,6 +672,8 @@ configurations.all {
         substitute module('com.github.GTNewHorizons:SpongePoweredMixin') using module(mixinProviderSpecNoClassifer) withClassifier("dev") because("Unimixins replaces other mixin mods")
         substitute module('com.github.GTNewHorizons:SpongeMixins') using module(mixinProviderSpecNoClassifer) withClassifier("dev") because("Unimixins replaces other mixin mods")
         substitute module('io.github.legacymoddingmc:unimixins') using module(mixinProviderSpecNoClassifer) withClassifier("dev") because("Our previous unimixins upload was missing the dev classifier")
+
+        substitute module('org.scala-lang:scala-library:2.11.1') using module('org.scala-lang:scala-library:2.11.5') because('To allow mixing with Java 8 targets')
     }
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -45,14 +45,14 @@ dependencies {
     compileOnly('com.github.GTNewHorizons:ExtraCells2:2.5.34:dev') { transitive = false }
     compileOnly('com.github.GTNewHorizons:ForestryMC:4.7.0:dev')
     compileOnly('com.github.GTNewHorizons:EnderIO:2.5.6:dev')
-    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.44.98:dev') {
+    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.44.106:dev') {
         exclude group: 'com.github.GTNewHorizons', module: 'AE2FluidCraft-Rework'
     }
     compileOnly('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
     compileOnly('com.gregoriust.gregtech:gregtech_1.7.10:6.14.23:dev') { transitive = false }
     compileOnly('com.github.GTNewHorizons:OpenComputers:1.9.19-GTNH:dev') { transitive = false }
-    compileOnly('com.github.GTNewHorizons:ThaumicEnergistics:1.5.3-GTNH:dev') { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Hodgepodge:2.3.38:dev") { transitive = false }
+    compileOnly('com.github.GTNewHorizons:ThaumicEnergistics:1.5.4-GTNH:dev') { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Hodgepodge:2.3.39:dev") { transitive = false }
 
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:DuraDisplay:1.1.7:dev")
 }

--- a/src/main/java/com/glodblock/github/client/gui/GuiEssentiaTerminal.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiEssentiaTerminal.java
@@ -1,7 +1,5 @@
 package com.glodblock.github.client.gui;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 
 import net.minecraft.client.gui.GuiButton;
@@ -80,13 +78,8 @@ public class GuiEssentiaTerminal extends GuiFluidMonitor {
     @Override
     protected void handleMouseClick(final Slot slot, final int slotIdx, final int ctrlDown, final int mouseButton) {
         if (slot instanceof SlotME && AspectUtil.isEssentiaContainer(player.inventory.getItemStack())) {
-            Map<Integer, IAEFluidStack> tmp = new HashMap<>();
-            ItemStack itemStack = this.player.inventory.getItemStack().copy();
-            tmp.put(0, ItemFluidDrop.getAeFluidStack(((SlotME) slot).getAEStack()));
-            if (!isShiftKeyDown()) {
-                itemStack.stackSize = 1;
-            }
-            FluidCraft.proxy.netHandler.sendToServer(new CPacketFluidUpdate(tmp, itemStack));
+            IAEFluidStack fluid = ItemFluidDrop.getAeFluidStack(((SlotME) slot).getAEStack());
+            FluidCraft.proxy.netHandler.sendToServer(new CPacketFluidUpdate(fluid, isShiftKeyDown()));
         }
         if (mouseButton == 3 && slot instanceof SlotME) {
             return;

--- a/src/main/java/com/glodblock/github/client/gui/GuiFluidTerminal.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiFluidTerminal.java
@@ -1,8 +1,5 @@
 package com.glodblock.github.client.gui;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.renderer.texture.TextureMap;
@@ -121,13 +118,8 @@ public class GuiFluidTerminal extends GuiFluidMonitor {
     @Override
     protected void handleMouseClick(final Slot slot, final int slotIdx, final int ctrlDown, final int mouseButton) {
         if (slot instanceof SlotME && Util.FluidUtil.isFluidContainer(player.inventory.getItemStack())) {
-            Map<Integer, IAEFluidStack> tmp = new HashMap<>();
-            ItemStack itemStack = this.player.inventory.getItemStack().copy();
-            tmp.put(0, ItemFluidDrop.getAeFluidStack(((SlotME) slot).getAEStack()));
-            if (!isShiftKeyDown()) {
-                itemStack.stackSize = 1;
-            }
-            FluidCraft.proxy.netHandler.sendToServer(new CPacketFluidUpdate(tmp, itemStack));
+            IAEFluidStack fluid = ItemFluidDrop.getAeFluidStack(((SlotME) slot).getAEStack());
+            FluidCraft.proxy.netHandler.sendToServer(new CPacketFluidUpdate(fluid, isShiftKeyDown()));
         }
         if (mouseButton == 3 && slot instanceof SlotME) {
             return;

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerEssentiaMonitor.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerEssentiaMonitor.java
@@ -1,7 +1,6 @@
 package com.glodblock.github.client.gui.container;
 
 import java.util.HashMap;
-import java.util.Map;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -23,7 +22,6 @@ import appeng.api.storage.data.IAEFluidStack;
 import appeng.container.slot.SlotPlayerHotBar;
 import appeng.container.slot.SlotPlayerInv;
 import appeng.util.Platform;
-import appeng.util.item.AEFluidStack;
 
 public class ContainerEssentiaMonitor extends ContainerFluidPortableCell {
 
@@ -37,110 +35,118 @@ public class ContainerEssentiaMonitor extends ContainerFluidPortableCell {
             Slot clickSlot = (Slot) this.inventorySlots.get(idx);
             if ((clickSlot instanceof SlotPlayerInv || clickSlot instanceof SlotPlayerHotBar) && clickSlot.getHasStack()
                     && AspectUtil.isEssentiaContainer(clickSlot.getStack())) {
-                ItemStack tis = clickSlot.getStack();
-                Map<Integer, IAEFluidStack> tmp = new HashMap<>();
-                tmp.put(0, null);
                 int index = Util.findItemInPlayerInvSlot(p, clickSlot.getStack());
-                FluidCraft.proxy.netHandler.sendToServer(new CPacketFluidUpdate(tmp, tis, index));
+                FluidCraft.proxy.netHandler.sendToServer(new CPacketFluidUpdate(index));
             }
         }
         return super.transferStackInSlot(p, idx);
     }
 
     @Override
-    public void postChange(Iterable<IAEFluidStack> change, ItemStack fluidContainer, EntityPlayer player,
-            int slotIndex) {
-        for (IAEFluidStack fluid : change) {
-            IAEFluidStack nfluid = this.monitor.getStorageList().findPrecise(fluid);
-            ItemStack out = fluidContainer.copy();
-            out.stackSize = 1;
-            if (AspectUtil.isEmptyEssentiaContainer(fluidContainer) && AspectUtil.isEssentiaGas(fluid)) {
-                // add essentia to jars
-                if (nfluid.getStackSize() / AspectUtil.R <= 0) continue;
-                final IAEFluidStack toExtract = nfluid.copy();
-                MutablePair<Integer, ItemStack> fillStack = AspectUtil
-                        .fillEssentiaFromGas(out, toExtract.getFluidStack());
-                if (fillStack == null || fillStack.right == null || fillStack.left <= 0) continue;
-                toExtract.setStackSize((long) fillStack.left * fluidContainer.stackSize);
-                IAEFluidStack tmp = this.host.getFluidInventory()
-                        .extractItems(toExtract, Actionable.SIMULATE, this.getActionSource());
-                if (tmp == null) continue;
-                fillStack.right.stackSize = (int) (tmp.getStackSize() / fillStack.left);
-                this.dropItem(fillStack.right);
-                out.stackSize = fillStack.right.stackSize;
-                if (AspectUtil.isEssentiaContainer(fillStack.right)) {
-                    this.host.getFluidInventory().extractItems(toExtract, Actionable.MODULATE, this.getActionSource());
-                    if ((int) (tmp.getStackSize() % fillStack.left) / AspectUtil.R > 0) {
-                        this.dropItem(
-                                AspectUtil.setAspectAmount(
-                                        fillStack.right,
-                                        (int) (tmp.getStackSize() % fillStack.left) / AspectUtil.R,
-                                        AspectUtil.getAspectFromGas(toExtract)),
-                                1);
-                        out.stackSize++;
-                    }
-                }
-            } else if (!AspectUtil.isEmptyEssentiaContainer(fluidContainer)) {
-                // add essentia to ae network
-                AEFluidStack fluidStack = AspectUtil.getAEGasFromContainer(fluidContainer);
-                if (fluidStack == null) {
-                    continue;
-                }
-                final IAEFluidStack aeFluidStack = fluidStack.copy();
-                // simulate result is incorrect. so I'm using other solution and ec2 both mod have same issues
-                final IAEFluidStack notInserted = this.host.getFluidInventory()
-                        .injectItems(aeFluidStack, Actionable.MODULATE, this.getActionSource());
-                MutablePair<Integer, ItemStack> drainStack = AspectUtil
-                        .drainEssentiaFromGas(out.copy(), aeFluidStack.getFluidStack());
-                if (notInserted != null && notInserted.getStackSize() > 0 && drainStack != null) {
-                    if (fluidStack.getStackSize() == notInserted.getStackSize()) continue;
-                    aeFluidStack.decStackSize(notInserted.getStackSize());
+    public void postChange(IAEFluidStack clientSelectedFluid, EntityPlayer player, int slotIndex, boolean shift) {
+        ItemStack targetStack;
+        if (slotIndex == -1) {
+            targetStack = player.inventory.getItemStack();
+        } else {
+            targetStack = player.inventory.getStackInSlot(slotIndex);
+        }
+        final int containersRequested = shift ? targetStack.stackSize : 1;
 
-                    if (drainStack.left > aeFluidStack.getStackSize()
-                            && AspectUtil.isEssentiaContainer(drainStack.right)) {
-                        aeFluidStack.setStackSize(drainStack.left - aeFluidStack.getStackSize());
-                        this.host.getFluidInventory()
-                                .extractItems(aeFluidStack, Actionable.MODULATE, this.getActionSource());
-                        continue;
-                    }
-
-                    // drop empty item
-                    this.dropItem(drainStack.right, (int) (aeFluidStack.getStackSize() / drainStack.left));
-                    out.stackSize = (int) (notInserted.getStackSize() / drainStack.left);
-                    if (AspectUtil.isEssentiaContainer(drainStack.right)) {
-                        if (notInserted.getStackSize() % drainStack.left > 0) {
-                            fluidStack.setStackSize((notInserted.getStackSize() % drainStack.left));
-                            AspectUtil.fillEssentiaFromGas(drainStack.right, fluidStack.getFluidStack());
-                            this.dropItem(drainStack.right, 1);
-                        }
-                    }
-                    if (slotIndex == -1) out.stackSize = fluidContainer.stackSize - out.stackSize;
-                } else if (drainStack != null) {
-                    if (slotIndex == -1) {
-                        out.stackSize = fluidContainer.stackSize;
-                    } else {
-                        out.stackSize = (int) (fluidContainer.stackSize
-                                - (aeFluidStack.getStackSize() / drainStack.left));
-                    }
-                    this.dropItem(drainStack.right, fluidContainer.stackSize); // drop empty item
-                }
-            } else {
-                continue;
+        IAEFluidStack storedFluid = this.monitor.getStorageList().findPrecise(clientSelectedFluid);
+        ItemStack out = targetStack.copy();
+        out.stackSize = 1;
+        if (AspectUtil.isEmptyEssentiaContainer(targetStack) && AspectUtil.isEssentiaGas(storedFluid)) {
+            // add essentia to jars
+            if (storedFluid.getStackSize() / AspectUtil.R <= 0) {
+                return;
             }
-            if (slotIndex == -1) {
-                player.inventory.getItemStack().stackSize = player.inventory.getItemStack().stackSize - out.stackSize;
-                if (player.inventory.getItemStack().stackSize > 0) {
-                    FluidCraft.proxy.netHandler.sendTo(
-                            new SPacketFluidUpdate(new HashMap<>(), player.inventory.getItemStack()),
-                            (EntityPlayerMP) player);
+            final IAEFluidStack toExtract = storedFluid.copy();
+            MutablePair<Integer, ItemStack> fillStack = AspectUtil.fillEssentiaFromGas(out, toExtract.getFluidStack());
+            if (fillStack == null || fillStack.right == null || fillStack.left <= 0) {
+                return;
+            }
+            toExtract.setStackSize((long) fillStack.left * containersRequested);
+            IAEFluidStack tmp = this.host.getFluidInventory()
+                    .extractItems(toExtract, Actionable.SIMULATE, this.getActionSource());
+            if (tmp == null) {
+                return;
+            }
+            fillStack.right.stackSize = (int) (tmp.getStackSize() / fillStack.left);
+            this.dropItem(fillStack.right);
+            out.stackSize = fillStack.right.stackSize;
+            if (AspectUtil.isEssentiaContainer(fillStack.right)) {
+                this.host.getFluidInventory().extractItems(toExtract, Actionable.MODULATE, this.getActionSource());
+                if ((int) (tmp.getStackSize() % fillStack.left) / AspectUtil.R > 0) {
+                    this.dropItem(
+                            AspectUtil.setAspectAmount(
+                                    fillStack.right,
+                                    (int) (tmp.getStackSize() % fillStack.left) / AspectUtil.R,
+                                    AspectUtil.getAspectFromGas(toExtract)),
+                            1);
+                    out.stackSize++;
+                }
+            }
+        } else if (!AspectUtil.isEmptyEssentiaContainer(targetStack)) {
+            // add essentia to ae network
+            ItemStack containerStack = targetStack.copy();
+            containerStack.stackSize = containersRequested;
+            IAEFluidStack fluidStack = AspectUtil.getAEGasFromContainer(containerStack);
+            if (fluidStack == null) {
+                return;
+            }
+            final IAEFluidStack aeFluidStack = fluidStack.copy();
+            // simulate result is incorrect. so I'm using other solution and ec2 both mod have same issues
+            final IAEFluidStack notInserted = this.host.getFluidInventory()
+                    .injectItems(aeFluidStack, Actionable.MODULATE, this.getActionSource());
+            MutablePair<Integer, ItemStack> drainStack = AspectUtil
+                    .drainEssentiaFromGas(out.copy(), aeFluidStack.getFluidStack());
+            if (notInserted != null && notInserted.getStackSize() > 0 && drainStack != null) {
+                if (fluidStack.getStackSize() == notInserted.getStackSize()) {
+                    return;
+                }
+                aeFluidStack.decStackSize(notInserted.getStackSize());
+
+                if (drainStack.left > aeFluidStack.getStackSize() && AspectUtil.isEssentiaContainer(drainStack.right)) {
+                    aeFluidStack.setStackSize(drainStack.left - aeFluidStack.getStackSize());
+                    this.host.getFluidInventory()
+                            .extractItems(aeFluidStack, Actionable.MODULATE, this.getActionSource());
+                    return;
+                }
+
+                // drop empty item
+                this.dropItem(drainStack.right, (int) (aeFluidStack.getStackSize() / drainStack.left));
+                out.stackSize = (int) (notInserted.getStackSize() / drainStack.left);
+                if (AspectUtil.isEssentiaContainer(drainStack.right)) {
+                    if (notInserted.getStackSize() % drainStack.left > 0) {
+                        fluidStack.setStackSize((notInserted.getStackSize() % drainStack.left));
+                        AspectUtil.fillEssentiaFromGas(drainStack.right, fluidStack.getFluidStack());
+                        this.dropItem(drainStack.right, 1);
+                    }
+                }
+                if (slotIndex == -1) out.stackSize = targetStack.stackSize - out.stackSize;
+            } else if (drainStack != null) {
+                if (slotIndex == -1) {
+                    out.stackSize = targetStack.stackSize;
                 } else {
-                    player.inventory.setItemStack(null);
-                    FluidCraft.proxy.netHandler
-                            .sendTo(new SPacketFluidUpdate(new HashMap<>()), (EntityPlayerMP) player);
+                    out.stackSize = (int) (targetStack.stackSize - (aeFluidStack.getStackSize() / drainStack.left));
                 }
-            } else {
-                player.inventory.setInventorySlotContents(slotIndex, out.stackSize > 0 ? out : null);
+                this.dropItem(drainStack.right, targetStack.stackSize); // drop empty item
             }
+        } else {
+            return;
+        }
+        if (slotIndex == -1) {
+            player.inventory.getItemStack().stackSize = player.inventory.getItemStack().stackSize - out.stackSize;
+            if (player.inventory.getItemStack().stackSize > 0) {
+                FluidCraft.proxy.netHandler.sendTo(
+                        new SPacketFluidUpdate(new HashMap<>(), player.inventory.getItemStack()),
+                        (EntityPlayerMP) player);
+            } else {
+                player.inventory.setItemStack(null);
+                FluidCraft.proxy.netHandler.sendTo(new SPacketFluidUpdate(new HashMap<>()), (EntityPlayerMP) player);
+            }
+        } else {
+            player.inventory.setInventorySlotContents(slotIndex, out.stackSize > 0 ? out : null);
         }
         this.detectAndSendChanges();
     }

--- a/src/main/java/com/glodblock/github/util/Util.java
+++ b/src/main/java/com/glodblock/github/util/Util.java
@@ -229,8 +229,7 @@ public final class Util {
     }
 
     public static AEFluidStack getAEFluidFromItem(ItemStack stack) {
-        if (stack != null
-                && (stack.getItem() instanceof IFluidContainerItem || FluidContainerRegistry.isContainer(stack))) {
+        if (stack != null) {
             if (stack.getItem() instanceof IFluidContainerItem) {
                 FluidStack fluid = ((IFluidContainerItem) stack.getItem()).getFluid(stack);
                 if (fluid != null) {
@@ -252,8 +251,7 @@ public final class Util {
     }
 
     public static FluidStack getFluidFromItem(ItemStack stack) {
-        if (stack != null
-                && (stack.getItem() instanceof IFluidContainerItem || FluidContainerRegistry.isContainer(stack))) {
+        if (stack != null) {
             if (stack.getItem() instanceof IFluidContainerItem) {
                 FluidStack fluid = ((IFluidContainerItem) stack.getItem()).getFluid(stack);
                 if (fluid != null) {


### PR DESCRIPTION
Optimized Packet to carry less data that is already available server-side.

Also fixed other small issues i found while looking at the code in ContainerFluidMonitor:
Fluid that would have gotten lost when working with buckets is now returned as a packet to the player.

ContainerEssentiaMonitor still has the potential to swallow some essentia when user has multiple storage busses on a jar in combination with essentia items that cant handle partial filling/emptying. (Not verified) This can be rectified as required at a later date.