### PR TITLE
Use correct priority increment amounts

### DIFF
--- a/src/main/java/com/glodblock/github/client/gui/GuiFCPriority.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiFCPriority.java
@@ -11,6 +11,7 @@ import com.glodblock.github.inventory.gui.GuiType;
 import com.glodblock.github.loader.ItemAndBlockHolder;
 
 import appeng.container.implementations.ContainerPriority;
+import appeng.core.AEConfig;
 import appeng.core.AELog;
 import appeng.core.localization.GuiText;
 import appeng.core.sync.network.NetworkHandler;
@@ -32,6 +33,11 @@ public class GuiFCPriority extends FCGuiAmount {
         this.submit.visible = false;
         this.buttonList.remove(this.submit);
         ((ContainerPriority) this.inventorySlots).setTextField(this.amountBox);
+    }
+
+    @Override
+    protected int getIncrementQuantity(int i) {
+        return AEConfig.instance.priorityByStacksAmounts(i);
     }
 
     @Override

--- a/src/main/java/com/glodblock/github/client/gui/base/FCGuiAmount.java
+++ b/src/main/java/com/glodblock/github/client/gui/base/FCGuiAmount.java
@@ -42,10 +42,11 @@ public abstract class FCGuiAmount extends AEBaseGui {
     @SuppressWarnings("unchecked")
     public void initGui() {
         super.initGui();
-        final int a = AEConfig.instance.craftItemsByStackAmounts(0);
-        final int b = AEConfig.instance.craftItemsByStackAmounts(1);
-        final int c = AEConfig.instance.craftItemsByStackAmounts(2);
-        final int d = AEConfig.instance.craftItemsByStackAmounts(3);
+
+        final int a = getIncrementQuantity(0);
+        final int b = getIncrementQuantity(1);
+        final int c = getIncrementQuantity(2);
+        final int d = getIncrementQuantity(3);
 
         this.buttonList.add(this.plus1 = new GuiButton(0, this.guiLeft + 20, this.guiTop + 26, 22, 20, "+" + a));
         this.buttonList.add(this.plus10 = new GuiButton(0, this.guiLeft + 48, this.guiTop + 26, 28, 20, "+" + b));
@@ -83,6 +84,10 @@ public abstract class FCGuiAmount extends AEBaseGui {
         this.amountBox.setTextColor(0xFFFFFF);
         this.amountBox.setVisible(true);
         this.amountBox.setFocused(true);
+    }
+
+    protected int getIncrementQuantity(int i) {
+        return AEConfig.instance.craftItemsByStackAmounts(i);
     }
 
     @Override


### PR DESCRIPTION
# Problem

When setting the priority on an ME Fluid Storage Bus, the displayed button values were using the `craftAmtButton#` config values instead of the `priorityAmtButton#` config values. This is inconsistent with the non-fluid ME Storage Bus behavior.

The interface in question:
![image](https://github.com/GTNewHorizons/AE2FluidCraft-Rework/assets/22136796/c747f21f-91ac-4a4e-a1ad-ec9c346e592f)


# Solution

Add an overridable method, `getIncrementQuantity`, to `FCGuiAmount` so that the subclass `GuiFCPriority` can specify to use priority values instead of the default crafting values. 