### PR TITLE
The fluid emitter does not change its state when there is no filter in it

### DIFF
--- a/src/main/java/com/glodblock/github/common/parts/PartFluidLevelEmitter.java
+++ b/src/main/java/com/glodblock/github/common/parts/PartFluidLevelEmitter.java
@@ -190,6 +190,11 @@ public class PartFluidLevelEmitter extends PartUpgradeable implements IStackWatc
             if (this.myWatcher != null && myStack != null) {
                 this.myWatcher.add(myStack);
             }
+
+            if (myStack == null) {
+                this.getProxy().getStorage().getFluidInventory().addListener(this, this.getProxy().getGrid());
+            }
+
             this.updateReportingValue(this.getProxy().getStorage().getFluidInventory());
         } catch (final GridAccessException ignored) {}
     }


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15462.

If you don't put a filter on the item emitter, it will react to any item on the network. However, if you don't put a filter in the fluid emitter it will simply not work as described in the issue above.

https://github.com/GTNewHorizons/AE2FluidCraft-Rework/assets/136671315/b04d4340-d391-4d5e-803d-efe530d56860

