### PR TITLE
Remove 'setInterfacePattern' method from OC Pattern Editor to prevent spawning items directly.

### DIFF
--- a/src/main/java/com/glodblock/github/crossmod/opencomputers/DriverOCPatternEditor.java
+++ b/src/main/java/com/glodblock/github/crossmod/opencomputers/DriverOCPatternEditor.java
@@ -188,16 +188,6 @@ public class DriverOCPatternEditor extends DriverSidedTileEntity {
             return new Object[] { stack };
         }
 
-        @Callback(
-                doc = "function([slot:number][, database:address, entry:number[, size:number]]):boolean -- Configure the interface.")
-        public Object[] setInterfaceConfiguration(Context context, Arguments args) {
-            IInventory config = tileEntity.getInternalInventory();
-            int slot = args.isString(0) ? 0 : optSlot(args, config, 0, 0);
-            config.setInventorySlotContents(slot, getStack(args));
-            context.pause(0.5);
-            return new Object[] { true };
-        }
-
         @Callback(doc = "function([slot:number]):table -- Get the given pattern in the interface.")
         public Object[] getInterfacePattern(Context context, Arguments args) {
             IInventory inv = tileEntity.getInternalInventory();


### PR DESCRIPTION
The 'setInterfacePattern' method can use OpenComputer to directly generate items in the game.

### How to generate item

1. Put an oc computer with OC Pattern Editor and a ME Interface. 

![image](https://github.com/GTNewHorizons/AE2FluidCraft-Rework/assets/27083866/ca5a3be7-fa1c-4259-a8e5-34e956b051c4)

2. Put a pattern in the first slot of me interface.
![image](https://github.com/GTNewHorizons/AE2FluidCraft-Rework/assets/27083866/7ee27c5d-4596-4b15-95e4-864f4e49d29b)

3. Run code in oc's computer

``` lua
local component = require("component")
local database = component.database
local p1 = component.me_interface
local p2 = component.oc_pattern_editor

p1.storeInterfacePatternOutput(1, 1, database.address, 1)
p2.setInterfaceConfiguration(1, database.address, 1, 64)
```

4. Then you generate the first output item of the pattern in OC Pattern Editor

Based on the above operations, items can be generated in GTNH 2.6.0 beta3, in Single Player mode.
Test in GTNH 2.6.0 beta3. 
![2024-05-31_23-41](https://github.com/GTNewHorizons/AE2FluidCraft-Rework/assets/27083866/32dd5a0a-71e0-4d57-865a-1753daed1110)
![2024-05-31_23-40](https://github.com/GTNewHorizons/AE2FluidCraft-Rework/assets/27083866/ae174b17-96bc-4534-9215-8e47a0a2cd81)
![2024-05-31_23-42](https://github.com/GTNewHorizons/AE2FluidCraft-Rework/assets/27083866/6604237d-f1c9-46b3-9c23-de0090a907d1)
![2024-05-31_23-43](https://github.com/GTNewHorizons/AE2FluidCraft-Rework/assets/27083866/95a633af-595f-48d9-b0df-3b34e7e418c1)

### Why just delete 'setInterfacePattern' method

After I compare 'setInterfacePattern' method of OC Pattern Editor with ME Interface's (https://github.com/GTNewHorizons/OpenComputers/blob/2c0252556c6345745e6ef3befa7a43115491712f/src/main/scala/li/cil/oc/integration/appeng/DriverBlockInterface.scala#L43). I found that in this method of ME Interface, ‘val config = tileEntity.getInventoryByName("config")’ is setting the configuration slot, but OC Pattern Editor does not have a configuration slot. 
And in the game, it seems that this method does not have much effect on the function of this block.

