### PR TITLE
Disable `useDependencyInformation`

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -10,9 +10,6 @@
     "authorList": ["GlodBlock"],
     "credits":"phantamanta44",
     "logoFile": "assets/ae2fc/logo.png",
-    "screenshots": [],
-    "useDependencyInformation": true,
-    "dependencies": ["appliedenergistics2"],
-    "requiredMods": ["appliedenergistics2"]
+    "screenshots": []
   }
 ]


### PR DESCRIPTION
`"useDependencyInformation": true` overrides the dependencies declared in the `@Mod` annotation with the dependencies declared in this file.