### PR TITLE
fix: add back universal terminal addon recipe

### DIFF
--- a/src/main/java/com/glodblock/github/loader/RecipeLoader.java
+++ b/src/main/java/com/glodblock/github/loader/RecipeLoader.java
@@ -722,8 +722,8 @@ public class RecipeLoader implements Runnable {
     }
 
     public static void runTerminalRecipe() {
-        ItemStack[] fc2Terms = { WIRELESS_FLUID_TERM.stack(), WIRELESS_PATTERN_TERM.stack(),
-                WIRELESS_INTERFACE_TERM.stack(), WIRELESS_LEVEL_TERM.stack() };
+        ItemStack[] fc2Terms = { WIRELESS_ULTRA_TERM.stack(), WIRELESS_FLUID_TERM.stack(),
+                WIRELESS_PATTERN_TERM.stack(), WIRELESS_INTERFACE_TERM.stack(), WIRELESS_LEVEL_TERM.stack() };
 
         for (ItemStack fc2term : fc2Terms) {
             if (fc2term != null) {


### PR DESCRIPTION
In #210 they refactored the way the mod add addon recipe, but forgot that universal terminal exist, and missed arguably the most important one in their list. This is a problem in the latest zeta nightly build.

https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/210/files#diff-ae9664e3868ee6b3424d94e9e7936ac321dfc630627cbf77e3120e3cc8b916cfR692-L649