### PR TITLE
Fix fluid storage bus that undergoes a full reset returns amount 0

### DIFF
--- a/src/main/java/com/glodblock/github/common/parts/PartFluidStorageBus.java
+++ b/src/main/java/com/glodblock/github/common/parts/PartFluidStorageBus.java
@@ -222,6 +222,10 @@ public class PartFluidStorageBus extends PartUpgradeable
         }
 
         final MEInventoryHandler<IAEFluidStack> out = this.getInternalHandler();
+        if (this.monitor != null) {
+            this.monitor.onTick();
+        }
+
         IItemList<IAEFluidStack> after = AEApi.instance().storage().createFluidList();
 
         if (in != out) {


### PR DESCRIPTION
Fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16039

This is only a partial fix, any listener called by `appeng.me.cache.NetworkMonitor#forceUpdate` that uses the monitor to get available items/the storage list will still have the amount as 0.
