### PR TITLE
Complete crafting jobs on networks without discretizer

### DIFF
--- a/src/main/java/com/glodblock/github/coremod/FCClassTransformer.java
+++ b/src/main/java/com/glodblock/github/coremod/FCClassTransformer.java
@@ -7,6 +7,7 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 
 import com.glodblock.github.coremod.transform.CraftingCpuTransformer;
+import com.glodblock.github.coremod.transform.CraftingGridCacheTransformer;
 import com.glodblock.github.coremod.transform.CraftingTreeNodeTransformer;
 import com.glodblock.github.coremod.transform.DualityInterfaceTransformer;
 import com.glodblock.github.coremod.transform.ExternalStorageRegistryTransformer;
@@ -20,6 +21,7 @@ public class FCClassTransformer implements IClassTransformer {
         Transform tform;
         switch (transformedName) {
             case "appeng.crafting.CraftingTreeNode" -> tform = CraftingTreeNodeTransformer.INSTANCE;
+            case "appeng.me.cache.CraftingGridCache" -> tform = CraftingGridCacheTransformer.INSTANCE;
             case "appeng.me.cluster.implementations.CraftingCPUCluster" -> tform = CraftingCpuTransformer.INSTANCE;
             case "appeng.helpers.DualityInterface" -> tform = DualityInterfaceTransformer.INSTANCE;
             case "appeng.client.gui.implementations.GuiCraftingCPU", "appeng.client.gui.implementations.GuiCraftConfirm", "net.p455w0rd.wirelesscraftingterminal.client.gui.GuiCraftConfirm", "appeng.client.gui.widgets.GuiCraftingTree" -> tform = GuiCraftingTransformer.INSTANCE;

--- a/src/main/java/com/glodblock/github/coremod/transform/CraftingGridCacheTransformer.java
+++ b/src/main/java/com/glodblock/github/coremod/transform/CraftingGridCacheTransformer.java
@@ -1,0 +1,67 @@
+package com.glodblock.github.coremod.transform;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import com.glodblock.github.coremod.FCClassTransformer;
+
+public class CraftingGridCacheTransformer extends FCClassTransformer.ClassMapper {
+
+    public static final CraftingGridCacheTransformer INSTANCE = new CraftingGridCacheTransformer();
+
+    private CraftingGridCacheTransformer() {
+        // NO-OP
+    }
+
+    @Override
+    protected ClassVisitor getClassMapper(ClassVisitor downstream) {
+        return new CraftingGridCacheTransformer.TransformCraftingGridCache(Opcodes.ASM5, downstream);
+    }
+
+    private static class TransformCraftingGridCache extends ClassVisitor {
+
+        TransformCraftingGridCache(int api, ClassVisitor cv) {
+            super(api, cv);
+        }
+
+        @Override
+        public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+            if (name.equals("getCellArray")) {
+                return new CraftingGridCacheTransformer.ReplaceGetCellArray(
+                        api,
+                        super.visitMethod(access, name, desc, signature, exceptions));
+            }
+            return super.visitMethod(access, name, desc, signature, exceptions);
+        }
+    }
+
+    private static class ReplaceGetCellArray extends MethodVisitor {
+
+        private final MethodVisitor target;
+
+        ReplaceGetCellArray(int api, MethodVisitor mv) {
+            // Original method is replaced
+            super(api, null);
+            target = mv;
+        }
+
+        @Override
+        public void visitCode() {
+            target.visitCode();
+            // Equivalent to
+            // return CoreModHooks::craftingGridCacheGetCellArray(this, channel);
+            target.visitVarInsn(Opcodes.ALOAD, 0);
+            target.visitVarInsn(Opcodes.ALOAD, 1);
+            target.visitMethodInsn(
+                    Opcodes.INVOKESTATIC,
+                    "com/glodblock/github/coremod/hooker/CoreModHooks",
+                    "craftingGridCacheGetCellArray",
+                    "(Lappeng/me/cache/CraftingGridCache;Lappeng/api/storage/StorageChannel;)Ljava/util/List;",
+                    false);
+            target.visitInsn(Opcodes.ARETURN);
+            target.visitMaxs(2, 3);
+            target.visitEnd();
+        }
+    }
+}

--- a/src/main/java/com/glodblock/github/inventory/CraftingGridCacheFluidInventoryProxyCell.java
+++ b/src/main/java/com/glodblock/github/inventory/CraftingGridCacheFluidInventoryProxyCell.java
@@ -1,0 +1,80 @@
+package com.glodblock.github.inventory;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.glodblock.github.common.item.ItemFluidDrop;
+
+import appeng.api.config.AccessRestriction;
+import appeng.api.config.Actionable;
+import appeng.api.networking.security.BaseActionSource;
+import appeng.api.storage.IMEInventoryHandler;
+import appeng.api.storage.StorageChannel;
+import appeng.api.storage.data.IAEFluidStack;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.api.storage.data.IItemList;
+import appeng.me.cache.CraftingGridCache;
+
+public class CraftingGridCacheFluidInventoryProxyCell implements IMEInventoryHandler<IAEFluidStack> {
+
+    private final CraftingGridCache inner;
+
+    public CraftingGridCacheFluidInventoryProxyCell(final CraftingGridCache craftingGridCache) {
+        inner = craftingGridCache;
+    }
+
+    @Override
+    public IAEFluidStack injectItems(IAEFluidStack input, Actionable type, BaseActionSource src) {
+        return ItemFluidDrop
+                .getAeFluidStack((IAEItemStack) inner.injectItems(ItemFluidDrop.newAeStack(input), type, src));
+    }
+
+    @Override
+    public IAEFluidStack extractItems(IAEFluidStack request, Actionable mode, BaseActionSource src) {
+        return null;
+    }
+
+    @Override
+    public IItemList<IAEFluidStack> getAvailableItems(IItemList<IAEFluidStack> out, int iteration) {
+        return out;
+    }
+
+    @Override
+    public IAEFluidStack getAvailableItem(@NotNull IAEFluidStack request, int iteration) {
+        return null;
+    }
+
+    @Override
+    public StorageChannel getChannel() {
+        return StorageChannel.FLUIDS;
+    }
+
+    @Override
+    public AccessRestriction getAccess() {
+        return inner.getAccess();
+    }
+
+    @Override
+    public boolean isPrioritized(IAEFluidStack input) {
+        return inner.isPrioritized(input);
+    }
+
+    @Override
+    public boolean canAccept(IAEFluidStack input) {
+        return inner.canAccept(ItemFluidDrop.newAeStack(input));
+    }
+
+    @Override
+    public int getPriority() {
+        return inner.getPriority();
+    }
+
+    @Override
+    public int getSlot() {
+        return inner.getSlot();
+    }
+
+    @Override
+    public boolean validForPass(int i) {
+        return inner.validForPass(i);
+    }
+}


### PR DESCRIPTION
Allows for this:
![image](https://github.com/user-attachments/assets/b630fcc0-192f-4364-a02f-5c52f6412e3c)
Only red network has the discretizer.

Previously, without a discretizer in the green network you could start jobs, but fluid products were never registered in crafting.  Discretizer was a dual-purpose block. The item inventory (`FluidDiscretizingInventory`) provided droplet representations of fluids in the network + conversion on droplet inject/extract. The fluid inventory (`FluidCraftingInventory`) converted injected fluids to droplets and attempted to inject them into the crafting grid.

This PR replaces the `CraftingGridCache::getCellArray` function responsible for getting the inventory handlers which are part of `StorageGrid`. On channel ITEMS there is no functional change, on channel FLUIDS instead of nothing it now returns a proxy to the `CraftingGridCache` which performs the same work as discretizer's fluid inventory (conversion to fluid and back).
As a bonus with no need for second discretizer the droplets no longer need to be doubled on green net.

The `FluidDiscretizingInventory` of discretizer is still needed
`FluidCraftingInventory` and `FluidCraftingInventoryHandler` of discretizer I think could be removed

Removed some static methods in `CoreModHooks` which were unused