### PR TITLE
Fix isAutoCraftingInventory returns false for CraftingGridCacheFluidInventoryProxyCell

### DIFF
--- a/src/main/java/com/glodblock/github/inventory/CraftingGridCacheFluidInventoryProxyCell.java
+++ b/src/main/java/com/glodblock/github/inventory/CraftingGridCacheFluidInventoryProxyCell.java
@@ -77,4 +77,9 @@ public class CraftingGridCacheFluidInventoryProxyCell implements IMEInventoryHan
     public boolean validForPass(int i) {
         return inner.validForPass(i);
     }
+
+    @Override
+    public boolean isAutoCraftingInventory() {
+        return inner.isAutoCraftingInventory();
+    }
 }


### PR DESCRIPTION
Crafting inventories need to return true for isAutoCraftingInventory, otherwise craft completion will break with sticky inventories.