### PR TITLE
Fix Level Maintainer causes stackoverflow

### DIFF
--- a/src/main/java/com/glodblock/github/common/parts/PartFluidStorageBus.java
+++ b/src/main/java/com/glodblock/github/common/parts/PartFluidStorageBus.java
@@ -15,16 +15,13 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Vec3;
-import net.minecraftforge.fluids.IFluidHandler;
 
 import com.glodblock.github.client.textures.FCPartsTexture;
 import com.glodblock.github.common.item.ItemFluidPacket;
-import com.glodblock.github.common.tile.TileFluidInterface;
 import com.glodblock.github.inventory.InventoryHandler;
 import com.glodblock.github.inventory.MEMonitorIFluidHandler;
 import com.glodblock.github.inventory.gui.GuiType;
 import com.glodblock.github.util.BlockPos;
-import com.glodblock.github.util.ModAndClassUtil;
 
 import appeng.api.AEApi;
 import appeng.api.config.AccessRestriction;
@@ -47,7 +44,6 @@ import appeng.api.networking.ticking.IGridTickable;
 import appeng.api.networking.ticking.ITickManager;
 import appeng.api.networking.ticking.TickRateModulation;
 import appeng.api.networking.ticking.TickingRequest;
-import appeng.api.parts.IPart;
 import appeng.api.parts.IPartCollisionHelper;
 import appeng.api.parts.IPartRenderHelper;
 import appeng.api.storage.ICellContainer;
@@ -70,14 +66,12 @@ import appeng.me.storage.MEInventoryHandler;
 import appeng.parts.automation.PartUpgradeable;
 import appeng.tile.inventory.AppEngInternalAEInventory;
 import appeng.tile.inventory.InvOperation;
-import appeng.tile.networking.TileCableBus;
 import appeng.util.IterationCounter;
 import appeng.util.Platform;
 import appeng.util.item.AEFluidStack;
 import appeng.util.prioitylist.PrecisePriorityList;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import extracells.tileentity.TileEntityFluidInterface;
 
 public class PartFluidStorageBus extends PartUpgradeable
         implements IGridTickable, ICellContainer, IMEMonitorHandlerReceiver<IAEFluidStack>, IPriorityHost {
@@ -291,38 +285,7 @@ public class PartFluidStorageBus extends PartUpgradeable
 
     @Override
     public void onNeighborChanged() {
-        TileEntity tile = this.getTile();
-        if (tile == null || this.getProxy() == null || !this.getProxy().isActive()) return;
-        BlockPos neighbor = new BlockPos(tile).getOffSet(this.getSide());
-        final TileEntity te = neighbor.getTileEntity();
-        // In case the TE was destroyed, we have to do a full reset immediately.
-        if (te instanceof TileCableBus) {
-            IPart iPart = ((TileCableBus) te).getPart(this.getSide().getOpposite());
-            if (iPart == null || iPart instanceof PartFluidInterface) {
-                this.resetCache(true);
-                this.resetCache();
-            }
-            if (ModAndClassUtil.EC2) {
-                if (iPart == null || iPart instanceof extracells.part.PartFluidInterface) {
-                    this.resetCache(true);
-                    this.resetCache();
-                }
-            }
-        } else if (te == null || te instanceof TileFluidInterface) {
-            this.resetCache(true);
-            this.resetCache();
-        } else if (ModAndClassUtil.EC2) {
-            if (te instanceof TileEntityFluidInterface) {
-                this.resetCache(true);
-                this.resetCache();
-            }
-        } else if (te instanceof IFluidHandler) {
-            this.resetCache(true);
-            this.resetCache();
-        } else {
-            this.resetCache(false);
-        }
-
+        this.resetCache(false);
     }
 
     @Override


### PR DESCRIPTION
Usually the `NetworkInventoryHandler` is save from infinite recursions since it keeps a list of networks it already visited. However in the case of the unfortunate combination of a Fluid Storage Bus and a Level Maintainer being right next to each other this gets broken.
The Level Maintainer will try to call `com.glodblock.github.common.tile.TileLevelMaintainer.InventoryRequest#updateState` if there are items that were not injected. This causes neighbors to be updated and if one of those neighbors is a Fluid Storage Bus it will undergo a full reset immediately. During the full reset of the Fluid Storage Bus a `appeng.me.cache.GridStorageCache#cellUpdate` will be executed, which resets the item and fluid networks. These will then be recreated lazily which causes the `NetworkInventoryHandler` to infinitely recurse.

This reset behavior of the Fluid Storage Bus has created issues in the past, see https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/222 . I am not sure why this reset behavior exists, since it dates back to the creation of the Fluid Storage Bus. Removing it fixes the stack overflow problem and I have noticed no adverse effects when loading in my world. On another note the Item Storage Bus also only does a non-immediate soft reset on neighbor changes.


Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17556
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17428