### PR TITLE
Fix Crash and revert mistake.

### DIFF
--- a/src/main/java/com/glodblock/github/inventory/FluidConvertingInventoryAdaptor.java
+++ b/src/main/java/com/glodblock/github/inventory/FluidConvertingInventoryAdaptor.java
@@ -31,9 +31,7 @@ import com.glodblock.github.util.Util;
 
 import appeng.api.config.FuzzyMode;
 import appeng.api.config.InsertionMode;
-import appeng.api.config.Settings;
 import appeng.api.config.Upgrades;
-import appeng.api.config.YesNo;
 import appeng.api.parts.IPart;
 import appeng.helpers.DualityInterface;
 import appeng.helpers.IInterfaceHost;
@@ -103,7 +101,7 @@ public class FluidConvertingInventoryAdaptor extends InventoryAdaptor {
             return InventoryAdaptor.getAdaptor(capProvider, face);
         if (InventoryAdaptor.getAdaptor(capProvider, face) == null) {
             if (capProvider instanceof IFluidHandler tank) {
-                if (!(tank.getTankInfo(face).length > 0)) return null;
+                if (tank.getTankInfo(face) == null || !(tank.getTankInfo(face).length > 0)) return null;
             } else {
                 return null;
             }
@@ -112,7 +110,7 @@ public class FluidConvertingInventoryAdaptor extends InventoryAdaptor {
         IFluidHandler fluid = capProvider instanceof IFluidHandler ? (IFluidHandler) capProvider : null;
         boolean onmi = false;
         if (inter instanceof TileInterface in) {
-            if (in.getConfigManager().getSetting(Settings.BLOCK) == YesNo.NO) onmi = in.getTargets().size() > 1;
+            onmi = in.getTargets().size() > 1;
         }
         return new FluidConvertingInventoryAdaptor(capProvider, item, fluid, face, new BlockPos(inter), onmi);
     }


### PR DESCRIPTION
Set single direction for omni in blocking mode only make thing worse. I though it will make better :fail:
conduits bandle is fluidhandler where tank info is null. I didnt though its possible :fail:
close: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17718