### PR TITLE
Fix that the clicked slot in a level maintainer is not determined correctly

### DIFF
--- a/src/main/java/com/glodblock/github/client/gui/GuiLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiLevelMaintainer.java
@@ -2,7 +2,6 @@ package com.glodblock.github.client.gui;
 
 import static com.glodblock.github.client.gui.container.ContainerLevelMaintainer.createLevelValues;
 
-import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -354,18 +353,21 @@ public class GuiLevelMaintainer extends AEBaseGui implements INEIGuiHandler {
         return null;
     }
 
-    private Rectangle getSlotArea(SlotFake slot) {
-        return new Rectangle(guiLeft + slot.getX(), guiTop + slot.getY(), 16, 16);
-    }
-
     @Override
     public boolean handleDragNDrop(GuiContainer gui, int mouseX, int mouseY, ItemStack draggedStack, int button) {
-        if (draggedStack != null) {
-            draggedStack.stackSize = 0;
+        if (draggedStack == null) {
+            return false;
         }
+
+        draggedStack.stackSize = 0;
+        Slot slotAtPosition = this.getSlotAtPosition(mouseX, mouseY);
+        if (slotAtPosition == null) {
+            return false;
+        }
+
         for (int i = 0; i < this.cont.getRequestSlots().length; i++) {
             SlotFluidConvertingFake slot = this.cont.getRequestSlots()[i];
-            if (getSlotArea(slot).contains(mouseX, mouseY) && draggedStack != null) {
+            if (slotAtPosition.equals(slot)) {
                 ItemStack itemStack = createLevelValues(draggedStack.copy());
                 itemStack.getTagCompound().setInteger(TLMTags.Index.tagName, i);
                 slot.putStack(itemStack);

--- a/src/main/resources/META-INF/ae2fc_at.cfg
+++ b/src/main/resources/META-INF/ae2fc_at.cfg
@@ -7,3 +7,5 @@ public net.minecraft.client.gui.inventory.GuiContainer field_147009_r # guiTop
 public net.minecraft.client.gui.inventory.GuiContainer field_147006_u #theSlot
 
 public net.minecraft.client.renderer.texture.TextureMap field_110574_e # mapRegisteredSprites
+
+protected net.minecraft.client.gui.inventory.GuiContainer func_146975_c(II)Lnet.minecraft.inventory.Slot; # getSlotAtPosition


### PR DESCRIPTION
The custom implementation `getSlotArea` doesn't determine the clicked slot correctly when clicking anywhere on the edge of the slot. This causes the `tagCompound` on the `itemStack` to not be set. However the slot change is still sent to the server (via NotEnoughEnergistic's GuiEventHandler) in this wrong state, which causes the maintainer to error for no visible reason.

Maybe Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17560
