### PR TITLE
Fix fluid is registered twice in crafting CPU

### DIFF
--- a/src/main/java/com/glodblock/github/common/tile/TileFluidDiscretizer.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileFluidDiscretizer.java
@@ -56,10 +56,8 @@ public class TileFluidDiscretizer extends AENetworkTile implements IPriorityHost
     @Override
     @SuppressWarnings("rawtypes")
     public List<IMEInventoryHandler> getCellArray(StorageChannel channel) {
-        if (getProxy().isActive()) {
-            if (channel == StorageChannel.ITEMS) {
-                return Collections.singletonList(fluidDropInv.invHandler);
-            }
+        if (channel == StorageChannel.ITEMS && getProxy().isActive()) {
+            return Collections.singletonList(fluidDropInv.invHandler);
         }
         return Collections.emptyList();
     }

--- a/src/main/java/com/glodblock/github/common/tile/TileFluidDiscretizer.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileFluidDiscretizer.java
@@ -1,15 +1,33 @@
 package com.glodblock.github.common.tile;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+
+import com.glodblock.github.api.FluidCraftAPI;
+import com.glodblock.github.common.item.ItemFluidDrop;
+
 import appeng.api.AEApi;
 import appeng.api.config.Actionable;
 import appeng.api.networking.GridFlags;
 import appeng.api.networking.energy.IEnergyGrid;
-import appeng.api.networking.events.*;
+import appeng.api.networking.events.MENetworkCellArrayUpdate;
+import appeng.api.networking.events.MENetworkChannelsChanged;
+import appeng.api.networking.events.MENetworkEventSubscribe;
+import appeng.api.networking.events.MENetworkPowerStatusChange;
+import appeng.api.networking.events.MENetworkStorageEvent;
 import appeng.api.networking.security.BaseActionSource;
 import appeng.api.networking.security.MachineSource;
 import appeng.api.networking.storage.IBaseMonitor;
 import appeng.api.networking.storage.IStorageGrid;
-import appeng.api.storage.*;
+import appeng.api.storage.ICellContainer;
+import appeng.api.storage.IMEInventory;
+import appeng.api.storage.IMEInventoryHandler;
+import appeng.api.storage.IMEMonitor;
+import appeng.api.storage.IMEMonitorHandlerReceiver;
+import appeng.api.storage.StorageChannel;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IItemList;
@@ -17,13 +35,6 @@ import appeng.helpers.IPriorityHost;
 import appeng.me.GridAccessException;
 import appeng.me.storage.MEInventoryHandler;
 import appeng.tile.grid.AENetworkTile;
-import com.glodblock.github.api.FluidCraftAPI;
-import com.glodblock.github.common.item.ItemFluidDrop;
-
-import javax.annotation.Nonnull;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 public class TileFluidDiscretizer extends AENetworkTile implements IPriorityHost, ICellContainer {
 


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17853

Description, see
> Yea the problem is from that PR, there is both the CraftingGridCacheFluidInventoryProxyCell and the fluid discretizer's fluid crafting inventory do the same thing of registering inserted fluids as droplets in CPUs. The Proxy is more flexible (always works, no need for discretizer, is not a fake inventory), so the fluid crafting inventory should be removed IMO
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17853#issuecomment-2458263725