### PR TITLE
Change GT5 u Mod check

### DIFF
--- a/src/main/java/com/glodblock/github/util/ModAndClassUtil.java
+++ b/src/main/java/com/glodblock/github/util/ModAndClassUtil.java
@@ -129,10 +129,9 @@ public final class ModAndClassUtil {
         }
 
         if (Loader.isModLoaded("gregtech") && !Loader.isModLoaded("gregapi")) {
-            try {
-                Class.forName("gregtech.api.recipe.RecipeMap");
+            if (Loader.isModLoaded("dreamcraft")) {
                 GT5NH = true;
-            } catch (ClassNotFoundException e) {
+            } else {
                 GT5 = true;
             }
         }


### PR DESCRIPTION
Removes the reflection that checks if GT5u is present because that will load the class and its static fields. Instead check if dreamcraft is loaded