### PR TITLE
No more drop drops from interface

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -35,21 +35,20 @@
  */
 dependencies {
     api('com.github.GTNewHorizons:NotEnoughItems:2.7.27-GTNH:dev')
-    api('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-532-GTNH:dev')
+    api('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-533-GTNH:dev')
     api('curse.maven:cofh-core-69162:2388751')
     api('com.github.GTNewHorizons:waila:1.8.2:dev')
-    api("com.github.GTNewHorizons:GTNHLib:0.6.5:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.6.6:dev")
 
     implementation("com.github.GTNewHorizons:WirelessCraftingTerminal:1.11.7:dev") {
         exclude group: 'com.github.GTNewHorizons', module: 'Applied-Energistics-2-Unofficial'
     }
 
-    compileOnly("com.github.GTNewHorizons:GTNHLib:0.6.5:dev") { transitive = false }
     compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.0.3:dev')
     compileOnly('com.github.GTNewHorizons:ExtraCells2:2.5.35:dev') { transitive = false }
     compileOnly('com.github.GTNewHorizons:ForestryMC:4.10.1:dev')
     compileOnly('com.github.GTNewHorizons:EnderIO:2.9.2:dev')
-    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.51.97:dev') {
+    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.51.99:dev') {
         exclude group: 'com.github.GTNewHorizons', module: 'AE2FluidCraft-Rework'
         exclude group: 'com.github.GTNewHorizons', module: 'Applied-Energistics-2-Unofficial'
     }
@@ -61,5 +60,4 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:Hodgepodge:2.6.22:dev") { transitive = false }
 
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:DuraDisplay:1.3.4:dev")
-	runtimeOnlyNonPublishable("com.github.GTNewHorizons:GTNHLib:0.6.5:dev")
 }

--- a/src/main/java/com/glodblock/github/common/tile/TileFluidInterface.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileFluidInterface.java
@@ -1,11 +1,13 @@
 package com.glodblock.github.common.tile;
 
 import java.io.IOException;
+import java.util.List;
 
 import javax.annotation.Nullable;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
@@ -217,5 +219,12 @@ public class TileFluidInterface extends TileInterface implements IDualHost {
         if (id >= 0 && id < 6) {
             getInternalFluid().setFluidInSlot(id, fluid);
         }
+    }
+
+    @Override
+    public void getDrops(World w, int x, int y, int z, List<ItemStack> drops) {
+        this.fluidDuality.addDrops(drops);
+        this.fluidDuality.convertDrops(drops, this.getInterfaceDuality().getWaitingToSend());
+        super.getDrops(w, x, y, z, drops);
     }
 }

--- a/src/main/java/com/glodblock/github/util/DualityFluidInterface.java
+++ b/src/main/java/com/glodblock/github/util/DualityFluidInterface.java
@@ -1,8 +1,10 @@
 package com.glodblock.github.util;
 
+import java.util.List;
 import java.util.Objects;
 
 import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -456,6 +458,26 @@ public class DualityFluidInterface implements IGridTickable, IStorageMonitorable
 
         InterfaceInventory(DualityFluidInterface tileInterface) {
             super(tileInterface.tanks);
+        }
+    }
+
+    public void addDrops(final List<ItemStack> drops) {
+        for (int i = 0; i < NUMBER_OF_TANKS; i++) {
+            ItemStack is = ItemFluidPacket.newStack(this.tanks.getFluidStackInSlot(i));
+            if (is != null) {
+                drops.add(is);
+            }
+        }
+    }
+
+    public void convertDrops(final List<ItemStack> drops, final List<ItemStack> waitingToSend) {
+        if (waitingToSend != null) {
+            for (final ItemStack is : waitingToSend) {
+                if (is != null && is.getItem() instanceof ItemFluidDrop) {
+                    drops.add(ItemFluidPacket.newStack(ItemFluidDrop.getFluidStack(is)));
+                    is.stackSize = 0;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Interface will drop fluids from tank as fluid packet previously it was voiding fluids in tanks. 
Should convert drops in fluid packet when fluid stuck in interface, but i cant test because never got drops instead fo packets.
req https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/661
Closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18482