### PR TITLE
Fix an issue that GT and AE2FC fluids could not be used with Creative Fluid Cell

### DIFF
--- a/src/main/java/com/glodblock/github/common/storage/CreativeFluidCellInventory.java
+++ b/src/main/java/com/glodblock/github/common/storage/CreativeFluidCellInventory.java
@@ -56,14 +56,12 @@ public class CreativeFluidCellInventory extends FluidCellInventory {
         IInventory inv = this.cellType.getConfigInventory(this.cellItem);
         for (int i = 0; i < inv.getSizeInventory(); i++) {
             ItemStack is = inv.getStackInSlot(i);
-            if (Util.FluidUtil.isFluidContainer(is)) {
-                FluidStack fs = Util.getFluidFromItem(is);
-                if (fs == null) continue;
-                IAEFluidStack iaeFluidStack = Util.FluidUtil.createAEFluidStack(fs);
-                if (this.cellFluids.findPrecise(iaeFluidStack) == null) {
-                    iaeFluidStack.setStackSize(Integer.MAX_VALUE * 1_000_000L);
-                    this.cellFluids.add(iaeFluidStack);
-                }
+            FluidStack fs = Util.getFluidFromItem(is);
+            if (fs == null) continue;
+            IAEFluidStack iaeFluidStack = Util.FluidUtil.createAEFluidStack(fs);
+            if (this.cellFluids.findPrecise(iaeFluidStack) == null) {
+                iaeFluidStack.setStackSize(Integer.MAX_VALUE * 1_000_000L);
+                this.cellFluids.add(iaeFluidStack);
             }
         }
     }


### PR DESCRIPTION
`Util.getFluidFromItem` handles not only FluidContainer but also GT and AE2FC fluids, and there is a null check, so there is no need to check whether it is a FluidContainer here.

before:
https://github.com/user-attachments/assets/47ad1518-8c42-41f3-be75-c244ef8ee448

after:
https://github.com/user-attachments/assets/ffff44f2-71be-4366-9dc6-cb8df5189a31

