### PR TITLE
Make the fluid handler more resilient.

### DIFF
--- a/src/main/java/com/glodblock/github/inventory/MEMonitorIFluidHandler.java
+++ b/src/main/java/com/glodblock/github/inventory/MEMonitorIFluidHandler.java
@@ -58,7 +58,7 @@ public class MEMonitorIFluidHandler implements IMEMonitor<IAEFluidStack> {
 
     public IAEFluidStack injectItems(IAEFluidStack input, Actionable type, BaseActionSource src) {
         if (!this.handler.canFill(this.side, input.getFluid())) {
-            return null;
+            return input;
         }
 
         int filled = this.handler.fill(this.side, input.getFluidStack(), type == Actionable.MODULATE);

--- a/src/main/java/com/glodblock/github/inventory/MEMonitorIFluidHandler.java
+++ b/src/main/java/com/glodblock/github/inventory/MEMonitorIFluidHandler.java
@@ -57,6 +57,10 @@ public class MEMonitorIFluidHandler implements IMEMonitor<IAEFluidStack> {
     }
 
     public IAEFluidStack injectItems(IAEFluidStack input, Actionable type, BaseActionSource src) {
+        if (!this.handler.canFill(this.side, input.getFluid())) {
+            return null;
+        }
+
         int filled = this.handler.fill(this.side, input.getFluidStack(), type == Actionable.MODULATE);
 
         if (type == Actionable.MODULATE) {
@@ -73,6 +77,9 @@ public class MEMonitorIFluidHandler implements IMEMonitor<IAEFluidStack> {
     }
 
     public IAEFluidStack extractItems(IAEFluidStack request, Actionable type, BaseActionSource src) {
+        if (!this.handler.canDrain(this.side, request.getFluid())) {
+            return null;
+        }
         FluidStack removed = this.handler.drain(this.side, request.getFluidStack(), type == Actionable.MODULATE);
         if (removed != null && removed.amount != 0) {
             IAEFluidStack o = request.copy();


### PR DESCRIPTION
This PR adds checks to the extract and insert functions using `canDrain` and `canFill` from the `IFluidHandler` interface to properly check whether a fluid can be drained or inserted before attempting to do so.

We discovered that the blockhead sink connected with a fluid storage bus always consumes fluids from its source if it has the available capacity regardless of fluid. While the sink is usually unavailable in the pack, the unwanted behaviour it caused could easily be reproduced in the future by any other tile entity with the same bug. So, it would be preferable to add some level of resilience to AE2FC. I've made a [PR ](https://github.com/GTNewHorizons/CookingForBlockheads/pull/53) to fix the root cause issue in the blockhead.

Adding some logging if the fluid extracted and the fluid requested isn't the same would be a good idea. Since there is no caching from the simulated phase, it will have to be done in both phases. It shouldn't try to refill the tank if something goes array, though, since assuming that the fill function would work correctly if the drain function isn't doesn't sound like the seeds of a dupe bug.

The bug in action:

https://github.com/user-attachments/assets/5df6c526-b062-43c8-86bd-935bba582a7d

