### PR TITLE
Partition gregtech fluids

### DIFF
--- a/src/main/java/com/glodblock/github/common/storage/FluidCellInventoryHandler.java
+++ b/src/main/java/com/glodblock/github/common/storage/FluidCellInventoryHandler.java
@@ -39,7 +39,9 @@ public class FluidCellInventoryHandler extends MEInventoryHandler<IAEFluidStack>
                 final ItemStack is = config.getStackInSlot(x);
                 final FluidStack fluid = Util.getFluidFromItem(is);
                 if (fluid != null) {
-                    priorityList.add(AEFluidStack.create(fluid));
+                    AEFluidStack stack = AEFluidStack.create(fluid);
+                    stack.setStackSize(1);
+                    priorityList.add(stack);
                 }
             }
             if (!priorityList.isEmpty()) {


### PR DESCRIPTION
When you partition a fluid cell by dragging the gregtech fluid from NEI / a recipe, that fluid has stacksize 0. That means it wont get recognized in the PrecisePriorityList. This PR fixes that issue. 
![image](https://github.com/user-attachments/assets/d992cf15-6ac4-480c-98e3-6cb7996adc16)

closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19406