### PR TITLE
made ItemBaseWirelessTerminal.canHandle null-safe

### DIFF
--- a/src/main/java/com/glodblock/github/common/item/ItemBaseWirelessTerminal.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemBaseWirelessTerminal.java
@@ -112,6 +112,9 @@ public class ItemBaseWirelessTerminal extends ToolWirelessTerminal implements II
 
     @Override
     public boolean canHandle(final ItemStack is) {
+        if (is == null) {
+            return false;
+        }
         return is.getItem() instanceof ItemBaseWirelessTerminal;
     }
 


### PR DESCRIPTION
fixes [Right clicking with the magnet card in hand causes a network handshake error.](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19423)
