### PR TITLE
Small improvements to the Level Maintainer GUI

### DIFF
--- a/src/main/java/com/glodblock/github/client/gui/GuiLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiLevelMaintainer.java
@@ -68,7 +68,7 @@ public class GuiLevelMaintainer extends AEBaseGui implements INEIGuiHandler {
     private final ContainerLevelMaintainer cont;
     private final Component[] component = new Component[TileLevelMaintainer.REQ_COUNT];
     private final MouseRegionManager mouseRegions = new MouseRegionManager(this);
-    private FCGuiTextField input;
+    private FCGuiTextField focusedTextField;
     private int lastWorkingTick;
     private int refreshTick;
     private final CoFHFontRenderer render;
@@ -206,7 +206,7 @@ public class GuiLevelMaintainer extends AEBaseGui implements INEIGuiHandler {
         drawTexturedModalRect(offsetX, offsetY, 0, 0, 176, ySize);
         int tick = this.refreshTick;
         int interval = 20;
-        if (tick > lastWorkingTick + interval && this.input == null) {
+        if (tick > lastWorkingTick + interval && this.focusedTextField == null) {
             FluidCraft.proxy.netHandler.sendToServer(new CPacketLevelMaintainer(Action.Refresh));
             lastWorkingTick = this.refreshTick;
         }
@@ -256,43 +256,43 @@ public class GuiLevelMaintainer extends AEBaseGui implements INEIGuiHandler {
     @Override
     protected void mouseClicked(final int xCoord, final int yCoord, final int btn) {
         if (btn == 0) {
-            if (input != null) {
-                input.setFocused(false);
+            if (focusedTextField != null) {
+                focusedTextField.setFocused(false);
             }
             for (Component com : this.component) {
                 FCGuiTextField textField = com.isMouseIn(xCoord, yCoord);
                 if (textField != null) {
                     textField.setFocused(true);
-                    this.input = textField;
+                    this.focusedTextField = textField;
                     super.mouseClicked(xCoord, yCoord, btn);
                     return;
                 }
             }
-            this.input = null;
+            this.focusedTextField = null;
         }
         super.mouseClicked(xCoord, yCoord, btn);
     }
 
     @Override
     protected void keyTyped(final char character, final int key) {
-        if (this.input == null) {
+        if (this.focusedTextField == null) {
             super.keyTyped(character, key);
             return;
         }
         if (!this.checkHotbarKeys(key)) {
-            if (!((character == ' ') && this.input.getText().isEmpty())) {
-                this.input.textboxKeyTyped(character, key);
+            if (!((character == ' ') && this.focusedTextField.getText().isEmpty())) {
+                this.focusedTextField.textboxKeyTyped(character, key);
             }
             super.keyTyped(character, key);
 
-            if (Double.isNaN(Calculator.conversion(this.input.getText()))) {
-                this.input.setTextColor(0xFF0000);
+            if (Double.isNaN(Calculator.conversion(this.focusedTextField.getText()))) {
+                this.focusedTextField.setTextColor(0xFF0000);
             } else {
-                this.input.setTextColor(0xFFFFFF);
+                this.focusedTextField.setTextColor(0xFFFFFF);
             }
             if (key == Keyboard.KEY_RETURN || key == Keyboard.KEY_NUMPADENTER) {
-                this.input.setFocused(false);
-                this.input = null;
+                this.focusedTextField.setFocused(false);
+                this.focusedTextField = null;
             }
         }
     }

--- a/src/main/java/com/glodblock/github/client/gui/GuiLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiLevelMaintainer.java
@@ -233,13 +233,11 @@ public class GuiLevelMaintainer extends AEBaseGui implements INEIGuiHandler {
             super.func_146977_a(new SlotSingleItem(slot));
             if (stack == null) return true;
             IAEItemStack fake = stack.copy();
-            final double stackSize = Calculator
-                    .conversion(this.component[slot.getSlotIndex()].getQty().textField.getText());
-            if (!Double.isNaN(stackSize)) {
-                fake.setStackSize((long) ArithHelper.round(stackSize, 0));
-            } else {
-                fake.setStackSize(0);
-            }
+
+            Widget qty = this.component[slot.getSlotIndex()].getQty();
+            qty.validate();
+            fake.setStackSize(qty.getAmount() != null ? qty.getAmount() : 0);
+
             GL11.glTranslatef(0.0f, 0.0f, 200.0f);
             aeRenderItem.setAeStack(fake);
             aeRenderItem.renderItemOverlayIntoGUI(

--- a/src/main/java/com/glodblock/github/client/gui/GuiLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiLevelMaintainer.java
@@ -15,6 +15,7 @@ import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.StatCollector;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import org.jetbrains.annotations.Nullable;
@@ -554,12 +555,24 @@ public class GuiLevelMaintainer extends AEBaseGui implements INEIGuiHandler {
         }
 
         public void draw() {
+            String current = amount != null
+                    ? StatCollector.translateToLocal(NameConst.TT_LEVEL_MAINTAINER_CURRENT) + " "
+                            + NumberFormat.getNumberInstance().format(amount)
+                            + "\n"
+                    : "";
             if (isShiftKeyDown()) {
-                this.setTooltip(render.wrapFormattedStringToWidth(NameConst.i18n(this.tooltip), xSize / 2));
+                this.setTooltip(
+                        render.wrapFormattedStringToWidth(
+                                StatCollector.translateToLocal(this.tooltip) + "\n"
+                                        + current
+                                        + "\n"
+                                        + StatCollector.translateToLocal(this.tooltip + ".hint"),
+                                xSize / 2));
             } else {
                 this.setTooltip(
                         render.wrapFormattedStringToWidth(
                                 NameConst.i18n(this.tooltip, "\n", false) + "\n"
+                                        + current
                                         + NameConst.i18n(NameConst.TT_SHIFT_FOR_MORE),
                                 (int) Math.floor(xSize * 0.8)));
             }

--- a/src/main/java/com/glodblock/github/client/gui/GuiLevelTerminal.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiLevelTerminal.java
@@ -28,6 +28,7 @@ import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
@@ -95,6 +96,7 @@ public class GuiLevelTerminal extends FCBaseMEGui implements IDropToFillTextFiel
     public static final int VIEW_WIDTH = 174;
     public static final int VIEW_LEFT = 8;
     private static final ResourceLocation TEX_BG = FluidCraft.resource("textures/gui/level_terminal.png");
+    private static final RenderItem renderItem = new RenderItem();
     protected int offsetY;
     private static final int offsetX = 21;
     protected static String searchFieldOutputsText = "";
@@ -502,7 +504,7 @@ public class GuiLevelTerminal extends FCBaseMEGui implements IDropToFillTextFiel
         Tessellator.instance.startDrawingQuads();
         int relY = 0;
         final int slotLeftMargin = (VIEW_WIDTH - entry.rowSize * 18);
-        float lastZLevel = aeRenderItem.zLevel;
+        float lastZLevel = renderItem.zLevel;
 
         entry.dispY = viewY;
         /* PASS 1: BG */
@@ -590,10 +592,9 @@ public class GuiLevelTerminal extends FCBaseMEGui implements IDropToFillTextFiel
                     GL11.glEnable(GL12.GL_RESCALE_NORMAL);
                     RenderHelper.enableGUIStandardItemLighting();
                     itemStack.stackSize = 0;
-                    aeRenderItem.setAeStack(null);
-                    aeRenderItem.zLevel = ITEM_STACK_Z - MAGIC_RENDER_ITEM_Z;
-                    aeRenderItem.renderItemAndEffectIntoGUI(fontRendererObj, mc.getTextureManager(), itemStack, 0, 0);
-                    aeRenderItem.renderItemOverlayIntoGUI(fontRendererObj, mc.getTextureManager(), itemStack, 0, 0);
+                    renderItem.zLevel = ITEM_STACK_Z - MAGIC_RENDER_ITEM_Z;
+                    renderItem.renderItemAndEffectIntoGUI(fontRendererObj, mc.getTextureManager(), itemStack, 0, 0);
+                    renderItem.renderItemOverlayIntoGUI(fontRendererObj, mc.getTextureManager(), itemStack, 0, 0);
                     GL11.glTranslatef(0.0f, 0.0f, ITEM_STACK_OVERLAY_Z - ITEM_STACK_Z);
                     int color = switch (state) {
                         case Idle -> FCGuiColors.StateIdle.getColor();
@@ -641,7 +642,7 @@ public class GuiLevelTerminal extends FCBaseMEGui implements IDropToFillTextFiel
             }
         }
         GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
-        aeRenderItem.zLevel = lastZLevel;
+        renderItem.zLevel = lastZLevel;
         return relY + 1;
     }
 

--- a/src/main/java/com/glodblock/github/network/CPacketLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/network/CPacketLevelMaintainer.java
@@ -54,12 +54,6 @@ public class CPacketLevelMaintainer implements IMessage {
         this.size = size;
     }
 
-    public CPacketLevelMaintainer(Action action, int slotIndex, String size) {
-        this.action = action;
-        this.slotIndex = slotIndex;
-        this.size = size.isEmpty() ? 0 : Long.parseLong(size);
-    }
-
     @Override
     public void fromBytes(ByteBuf buf) {
         this.action = Action.values()[buf.readInt()];


### PR DESCRIPTION
- Now gtnhlib is hard dep so we will clean up around TextField

- Submit values with enter key
Previously, it would remove focus but not send values.

- Shows the value in the tooltip
Improved the issue where the text field was narrow and the value was difficult to read.
![2025-04-09_17 30 22](https://github.com/user-attachments/assets/6cd79717-c482-4f45-84eb-bcbe50ed8e91)

- Prevent stack sizes from being rendered behind items in Level Terminal
Use `RenderItem` because `AppEngRenderItem` probably doesn't allow us to disable stack size drawing.
before:
![image](https://github.com/user-attachments/assets/a1cb1c8e-df73-4425-aaca-d43b4667283e)
