### PR TITLE
remove Baubles as a mandatory dependency

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -44,7 +44,7 @@ dependencies {
         exclude group: 'com.github.GTNewHorizons', module: 'Applied-Energistics-2-Unofficial'
     }
 
-    compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.1.7-GTNH:dev')
+    compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.1.7-GTNH:dev'){ transitive = false }
     compileOnly('com.github.GTNewHorizons:ExtraCells2:2.5.35:dev') { transitive = false }
     compileOnly('com.github.GTNewHorizons:ForestryMC:4.10.7:dev')
     compileOnly('com.github.GTNewHorizons:EnderIO:2.9.12:dev')


### PR DESCRIPTION
I'm sorry, but I don't understand why FC requires Baubles as a mandatory dependency. This forces users to install Baubles as a prerequisite when using FC. So i suspect this might be an unintended behavior. If this has caused any inconvenience, please accept my apologies.