### PR TITLE
Fix fluid import/export bus GUI when WAILA is disabled

### DIFF
--- a/src/main/java/com/glodblock/github/crossmod/waila/part/SpeedWailaDataProvider.java
+++ b/src/main/java/com/glodblock/github/crossmod/waila/part/SpeedWailaDataProvider.java
@@ -7,6 +7,8 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
+import com.glodblock.github.common.parts.PartFluidExportBus;
+import com.glodblock.github.common.parts.PartFluidImportBus;
 import com.glodblock.github.common.parts.base.FCSharedFluidBus;
 import com.glodblock.github.crossmod.waila.Tooltip;
 
@@ -20,9 +22,14 @@ public class SpeedWailaDataProvider extends BasePartWailaDataProvider {
     @Override
     public List<String> getWailaBody(final IPart part, final List<String> currentToolTip,
             final IWailaDataAccessor accessor, final IWailaConfigHandler config) {
-        if (part instanceof FCSharedFluidBus) {
-            part.readFromNBT(accessor.getNBTData());
-            currentToolTip.add(Tooltip.partFluidBusFormat(((FCSharedFluidBus) part).calculateAmountToSend() / 5));
+        if (part instanceof PartFluidExportBus bus) {
+            PartFluidExportBus tmpBus = new PartFluidExportBus(bus.getItemStack());
+            tmpBus.readFromNBT(accessor.getNBTData());
+            currentToolTip.add(Tooltip.partFluidBusFormat(tmpBus.calculateAmountToSend() / 5));
+        } else if (part instanceof PartFluidImportBus bus) {
+            PartFluidImportBus tmpBus = new PartFluidImportBus(bus.getItemStack());
+            tmpBus.readFromNBT(accessor.getNBTData());
+            currentToolTip.add(Tooltip.partFluidBusFormat(tmpBus.calculateAmountToSend() / 5));
         }
         return currentToolTip;
     }

--- a/src/main/java/com/glodblock/github/crossmod/waila/part/SpeedWailaDataProvider.java
+++ b/src/main/java/com/glodblock/github/crossmod/waila/part/SpeedWailaDataProvider.java
@@ -7,8 +7,6 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
-import com.glodblock.github.common.parts.PartFluidExportBus;
-import com.glodblock.github.common.parts.PartFluidImportBus;
 import com.glodblock.github.common.parts.base.FCSharedFluidBus;
 import com.glodblock.github.crossmod.waila.Tooltip;
 
@@ -22,14 +20,8 @@ public class SpeedWailaDataProvider extends BasePartWailaDataProvider {
     @Override
     public List<String> getWailaBody(final IPart part, final List<String> currentToolTip,
             final IWailaDataAccessor accessor, final IWailaConfigHandler config) {
-        if (part instanceof PartFluidExportBus bus) {
-            PartFluidExportBus tmpBus = new PartFluidExportBus(bus.getItemStack());
-            tmpBus.readFromNBT(accessor.getNBTData());
-            currentToolTip.add(Tooltip.partFluidBusFormat(tmpBus.calculateAmountToSend() / 5));
-        } else if (part instanceof PartFluidImportBus bus) {
-            PartFluidImportBus tmpBus = new PartFluidImportBus(bus.getItemStack());
-            tmpBus.readFromNBT(accessor.getNBTData());
-            currentToolTip.add(Tooltip.partFluidBusFormat(tmpBus.calculateAmountToSend() / 5));
+        if (accessor.getNBTData().hasKey("BusSpeed")) {
+            currentToolTip.add(Tooltip.partFluidBusFormat(accessor.getNBTData().getInteger("BusSpeed")));
         }
         return currentToolTip;
     }
@@ -37,8 +29,8 @@ public class SpeedWailaDataProvider extends BasePartWailaDataProvider {
     @Override
     public NBTTagCompound getNBTData(final EntityPlayerMP player, final IPart part, final TileEntity te,
             final NBTTagCompound tag, final World world, final int x, final int y, final int z) {
-        if (part instanceof FCSharedFluidBus) {
-            part.writeToNBT(tag);
+        if (part instanceof FCSharedFluidBus bus) {
+            tag.setInteger("BusSpeed", bus.calculateAmountToSend() / 5);
         }
         return tag;
     }


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18938

I don't know why the issue only occurs when WAILA is disabled, but anyway it can be fixed by making sure WAILA Provider doesn't overwrite the bus inventory.