### PR TITLE
Fix div by zero

### DIFF
--- a/src/main/java/com/glodblock/github/common/storage/FluidCellInventory.java
+++ b/src/main/java/com/glodblock/github/common/storage/FluidCellInventory.java
@@ -200,7 +200,7 @@ public class FluidCellInventory implements IFluidCellInventory {
 
     @Override
     public long getRemainingFluidTypes() {
-        final long basedOnStorage = this.getFreeBytes() / this.getBytesPerType();
+        final long basedOnStorage = this.getFreeBytes() / Math.max(1, this.getBytesPerType());
         final long baseOnTotal = this.getTotalFluidTypes() - this.getStoredFluidTypes();
         return Math.min(basedOnStorage, baseOnTotal);
     }


### PR DESCRIPTION
This fixes a minor division by zero when using opencomputers to get the list of fluids on an AE network that has void cells on it.

```
java.lang.ArithmeticException: / by zero
	at Launch//com.glodblock.github.common.storage.FluidCellInventory.getRemainingFluidTypes(FluidCellInventory.java:203) ~[FluidCellInventory.class:?]
	at Launch//li.cil.oc.integration.ae2fc.ConverterFluidCellInventory.convert(ConverterFluidCellInventory.java:23) ~[ConverterFluidCellInventory.class:?]
	at Launch//li.cil.oc.integration.ae2fc.ConverterFluidCellInventory.convert(ConverterFluidCellInventory.java:45) ~[ConverterFluidCellInventory.class:?]
	at Launch//li.cil.oc.server.driver.Registry$$anonfun$convertRecursively$1.apply(Registry.scala:217) ~[Registry$$anonfun$convertRecursively$1.class:?]
	at Launch//li.cil.oc.server.driver.Registry$$anonfun$convertRecursively$1.apply(Registry.scala:217) ~[Registry$$anonfun$convertRecursively$1.class:?]
	at Launch//scala.collection.mutable.ResizableArray$class.foreach(ResizableArray.scala:59) ~[scala-library-2.11.1.jar:?]
	at Launch//scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:48) ~[scala-library-2.11.1.jar:?]
```