### PR TITLE
Fix Universal Terminal restock hotkey chat message saying the opposite of the current state

### DIFF
--- a/src/main/java/com/glodblock/github/network/CPacketValueConfig.java
+++ b/src/main/java/com/glodblock/github/network/CPacketValueConfig.java
@@ -67,7 +67,7 @@ public class CPacketValueConfig implements IMessage {
                             player.addChatMessage(
                                     new ChatComponentText(
                                             StatCollector.translateToLocal(
-                                                    !Util.isRestock(wirelessTerm)
+                                                    Util.isRestock(wirelessTerm)
                                                             ? NameConst.TT_ULTRA_TERMINAL_RESTOCK_ON
                                                             : NameConst.TT_ULTRA_TERMINAL_RESTOCK_OFF)));
                         } else {


### PR DESCRIPTION
A minor logic error had the chat message given to the player say the opposite state after pressing the Universal Wireless Terminal Restock hotkey.