### PR TITLE
[Feature] Creative-like block select with withdrawl from AE system

### DIFF
--- a/src/main/java/com/glodblock/github/loader/ChannelLoader.java
+++ b/src/main/java/com/glodblock/github/loader/ChannelLoader.java
@@ -16,6 +16,7 @@ import com.glodblock.github.network.CPacketLevelTerminalCommands;
 import com.glodblock.github.network.CPacketPatternMultiSet;
 import com.glodblock.github.network.CPacketPatternValueSet;
 import com.glodblock.github.network.CPacketRenamer;
+import com.glodblock.github.network.CPacketSelectBlockWithdraw;
 import com.glodblock.github.network.CPacketSwitchGuis;
 import com.glodblock.github.network.CPacketTransferRecipe;
 import com.glodblock.github.network.CPacketValueConfig;
@@ -93,6 +94,11 @@ public class ChannelLoader implements Runnable {
                 SPacketLevelMaintainerGuiUpdate.class,
                 id++,
                 Side.CLIENT);
+        netHandler.registerMessage(
+                new CPacketSelectBlockWithdraw.Handler(),
+                CPacketSelectBlockWithdraw.class,
+                id++,
+                Side.SERVER);
     }
 
     public static void sendPacketToAllPlayers(Packet packet, World world) {

--- a/src/main/java/com/glodblock/github/loader/KeybindLoader.java
+++ b/src/main/java/com/glodblock/github/loader/KeybindLoader.java
@@ -4,6 +4,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityClientPlayerMP;
 import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.MovingObjectPosition;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -102,11 +103,13 @@ public class KeybindLoader implements Runnable {
         // Ensure the player has the wireless terminal
         ImmutablePair<Integer, ItemStack> terminalAndInventorySlot = Util.getUltraWirelessTerm(player);
         if (terminalAndInventorySlot == null) {
+            player.addChatMessage(new ChatComponentText("Could not find wireless terminal."));
             return;
         }
 
         ItemStack terminal = terminalAndInventorySlot.getRight();
         if (terminal == null || !(terminal.getItem() instanceof ItemWirelessUltraTerminal)) {
+            player.addChatMessage(new ChatComponentText("Terminal must be universal version."));
             return;
         }
 

--- a/src/main/java/com/glodblock/github/network/CPacketSelectBlockWithdraw.java
+++ b/src/main/java/com/glodblock/github/network/CPacketSelectBlockWithdraw.java
@@ -205,6 +205,10 @@ public class CPacketSelectBlockWithdraw implements IMessage {
          * @param slot2     The index of the second ItemStack to move.
          */
         private void swapInventorySlots(InventoryPlayer inventory, int slot1, int slot2) {
+            if (slot1 == slot2) {
+                return;
+            }
+
             // Get the stacks from both slots
             ItemStack sourceStack = inventory.getStackInSlot(slot1);
             ItemStack destinationStack = inventory.getStackInSlot(slot2);

--- a/src/main/java/com/glodblock/github/network/CPacketSelectBlockWithdraw.java
+++ b/src/main/java/com/glodblock/github/network/CPacketSelectBlockWithdraw.java
@@ -1,0 +1,122 @@
+package com.glodblock.github.network;
+
+import net.minecraft.block.Block;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+
+import com.glodblock.github.common.item.ItemWirelessUltraTerminal;
+import com.glodblock.github.inventory.item.WirelessCraftingTerminalInventory;
+import com.glodblock.github.util.Util;
+
+import appeng.api.AEApi;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.api.storage.data.IAEStack;
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import io.netty.buffer.ByteBuf;
+
+public class CPacketSelectBlockWithdraw implements IMessage {
+
+    private int blockX;
+    private int blockY;
+    private int blockZ;
+
+    public CPacketSelectBlockWithdraw() {
+        // Required for FML
+    }
+
+    public CPacketSelectBlockWithdraw(int x, int y, int z) {
+        this.blockX = x;
+        this.blockY = y;
+        this.blockZ = z;
+    }
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        this.blockX = buf.readInt();
+        this.blockY = buf.readInt();
+        this.blockZ = buf.readInt();
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        buf.writeInt(this.blockX);
+        buf.writeInt(this.blockY);
+        buf.writeInt(this.blockZ);
+    }
+
+    public static class Handler implements IMessageHandler<CPacketSelectBlockWithdraw, IMessage> {
+
+        @Override
+        public IMessage onMessage(CPacketSelectBlockWithdraw message, MessageContext ctx) {
+            EntityPlayerMP player = ctx.getServerHandler().playerEntity;
+            if (player == null || player.inventory == null) {
+                return null;
+            }
+            World world = player.worldObj;
+
+            // Ensure the player has the wireless terminal
+            ImmutablePair<Integer, ItemStack> terminalAndInventorySlot = Util.getUltraWirelessTerm(player);
+            if (terminalAndInventorySlot == null) {
+                return null;
+            }
+
+            ItemStack terminalStack = terminalAndInventorySlot.getRight();
+            if (terminalStack == null || !(terminalStack.getItem() instanceof ItemWirelessUltraTerminal)) {
+                return null;
+            }
+
+            // Create the terminal inventory handler
+            WirelessCraftingTerminalInventory terminalInventory = new WirelessCraftingTerminalInventory(
+                    terminalStack,
+                    terminalAndInventorySlot.getLeft(),
+                    Util.getWirelessGrid(terminalStack), // This provides the IGrid
+                    player);
+
+            // Get the target block
+            Block targetBlock = world.getBlock(message.blockX, message.blockY, message.blockZ);
+            if (targetBlock == Blocks.air) {
+                return null; // Don't try to withdraw air
+            }
+
+            Item targetItem = Item.getItemFromBlock(targetBlock);
+            if (targetItem == null) {
+                return null; // Should not happen for non-air blocks
+            }
+
+            // Create an ItemStack for the target block, try to get a full stack
+            ItemStack targetItemStack = new ItemStack(
+                    targetItem,
+                    1,
+                    world.getBlockMetadata(message.blockX, message.blockY, message.blockZ));
+            targetItemStack.stackSize = targetItem.getItemStackLimit(targetItemStack);
+
+            IAEItemStack targetAeItemStack = AEApi.instance().storage().createItemStack(targetItemStack);
+            if (targetAeItemStack == null) {
+                return null;
+            }
+
+            // Extract items from the network
+            IAEStack<?> extractedStack = terminalInventory.extractItems(targetAeItemStack);
+
+            if (extractedStack instanceof IAEItemStack extractedAeItemStack && extractedStack.getStackSize() > 0) {
+                ItemStack itemsToGive = extractedAeItemStack.getItemStack();
+                if (itemsToGive != null && itemsToGive.stackSize > 0) {
+                    player.inventory.addItemStackToInventory(itemsToGive);
+                    player.inventory.markDirty(); // Mark inventory as dirty to sync with client
+                    // If player has a container open, update it
+                    if (player.openContainer != null) {
+                        player.openContainer.detectAndSendChanges();
+                    }
+                }
+            }
+            return null; // No reply packet needed
+        }
+    }
+}

--- a/src/main/java/com/glodblock/github/network/CPacketSelectBlockWithdraw.java
+++ b/src/main/java/com/glodblock/github/network/CPacketSelectBlockWithdraw.java
@@ -138,9 +138,7 @@ public class CPacketSelectBlockWithdraw implements IMessage {
             // 4. Consolidate if multiple partial stacks exist.
             ItemStack consolidatedStack = null;
             int consolidatedStackSlot = -1;
-            for (int i = partialStackSlotsList.size() - 1; i >= 0; --i) {
-                Integer partialStackSlot = partialStackSlotsList.get(i);
-
+            for (Integer partialStackSlot : partialStackSlotsList) {
                 if (consolidatedStack == null) {
                     consolidatedStack = player.inventory.getStackInSlot(partialStackSlot);
                     consolidatedStackSlot = partialStackSlot;

--- a/src/main/java/com/glodblock/github/network/CPacketSelectBlockWithdraw.java
+++ b/src/main/java/com/glodblock/github/network/CPacketSelectBlockWithdraw.java
@@ -1,7 +1,11 @@
 package com.glodblock.github.network;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -90,33 +94,147 @@ public class CPacketSelectBlockWithdraw implements IMessage {
                 return null; // Should not happen for non-air blocks
             }
 
-            // Create an ItemStack for the target block, try to get a full stack
-            ItemStack targetItemStack = new ItemStack(
+            // Check player inventory for existing stacks to determine how much to withdraw.
+            ItemStack itemToFind = new ItemStack(
                     targetItem,
                     1,
                     world.getBlockMetadata(message.blockX, message.blockY, message.blockZ));
-            targetItemStack.stackSize = targetItem.getItemStackLimit(targetItemStack);
 
+            // 1. Initial Scan for full/partial stacks
+            int fullStackSlot = -1;
+            List<Integer> partialStackSlotsList = new ArrayList<>();
+            for (int i = 0; i < player.inventory.mainInventory.length; i++) {
+                ItemStack stackInSlot = player.inventory.mainInventory[i];
+                if (stackInSlot != null && stackInSlot.isItemEqual(itemToFind)
+                        && ItemStack.areItemStackTagsEqual(stackInSlot, itemToFind)) {
+                    if (stackInSlot.stackSize >= stackInSlot.getMaxStackSize()) {
+                        fullStackSlot = i;
+                        break; // Found a full stack, no need to do anything.
+                    }
+                    partialStackSlotsList.add(i);
+                }
+            }
+
+            // 2. If a full stack already exists, put in active slot and return.
+            if (fullStackSlot >= 0) {
+                swapInventorySlots(player.inventory, fullStackSlot, player.inventory.currentItem);
+                return null;
+            }
+
+            // 3. If there are no partial stacks and the player's inventory is full,
+            // then return since we cannot add a retrieved stack to a full inventory
+            int nextEmptySlot = player.inventory.getFirstEmptyStack();
+            if (partialStackSlotsList.isEmpty() && nextEmptySlot == -1) {
+                return null;
+            }
+
+            // 4. Consolidate if multiple partial stacks exist.
+            ItemStack consolidatedStack = null;
+            int consolidatedStackSlot = -1;
+            for (int i = partialStackSlotsList.size() - 1; i >= 0; --i) {
+                Integer partialStackSlot = partialStackSlotsList.get(i);
+
+                if (consolidatedStack == null) {
+                    consolidatedStack = player.inventory.getStackInSlot(partialStackSlot);
+                    consolidatedStackSlot = partialStackSlot;
+                } else {
+                    consolidateItemStacks(player.inventory, partialStackSlot, consolidatedStackSlot);
+                }
+
+                // Check if we created a full stack of items
+                if (consolidatedStack.stackSize == consolidatedStack.getMaxStackSize()) {
+                    swapInventorySlots(player.inventory, consolidatedStackSlot, player.inventory.currentItem);
+                    return null;
+                }
+            }
+
+            // 5. Calculate withdrawal amount
+            int amountToWithdraw = consolidatedStack == null ? itemToFind.getMaxStackSize()
+                    : itemToFind.getMaxStackSize() - consolidatedStack.stackSize;
+            if (amountToWithdraw <= 0) {
+                return null;
+            }
+
+            // Create an IAEItemStack for the target block with the calculated amount
+            ItemStack targetItemStack = itemToFind.copy();
+            targetItemStack.stackSize = amountToWithdraw;
             IAEItemStack targetAeItemStack = AEApi.instance().storage().createItemStack(targetItemStack);
             if (targetAeItemStack == null) {
                 return null;
             }
 
-            // Extract items from the network
+            // 6. Extract items from the network
             IAEStack<?> extractedStack = terminalInventory.extractItems(targetAeItemStack);
-
             if (extractedStack instanceof IAEItemStack extractedAeItemStack && extractedStack.getStackSize() > 0) {
                 ItemStack itemsToGive = extractedAeItemStack.getItemStack();
+                // Update the player's inventory with the withdrawn items
                 if (itemsToGive != null && itemsToGive.stackSize > 0) {
-                    player.inventory.addItemStackToInventory(itemsToGive);
-                    player.inventory.markDirty(); // Mark inventory as dirty to sync with client
-                    // If player has a container open, update it
-                    if (player.openContainer != null) {
-                        player.openContainer.detectAndSendChanges();
+                    if (consolidatedStack == null) {
+                        player.inventory.setInventorySlotContents(nextEmptySlot, itemsToGive);
+                        swapInventorySlots(player.inventory, player.inventory.currentItem, nextEmptySlot);
+                    } else {
+                        consolidatedStack.stackSize += itemsToGive.stackSize;
+                        swapInventorySlots(player.inventory, player.inventory.currentItem, consolidatedStackSlot);
                     }
                 }
             }
             return null; // No reply packet needed
+        }
+
+        /**
+         * Moves an ItemStack from a source slot to a destination slot in the player's inventory. If the destination
+         * slot is occupied, the items are swapped.
+         *
+         * @param inventory The player's inventory.
+         * @param slot1     The index of the first ItemStack to move.
+         * @param slot2     The index of the second ItemStack to move.
+         */
+        private void swapInventorySlots(InventoryPlayer inventory, int slot1, int slot2) {
+            // Get the stacks from both slots
+            ItemStack sourceStack = inventory.getStackInSlot(slot1);
+            ItemStack destinationStack = inventory.getStackInSlot(slot2);
+
+            // Set the destination slot with the source stack (even if it's null)
+            inventory.setInventorySlotContents(slot2, sourceStack);
+
+            // Set the source slot with the original destination stack
+            inventory.setInventorySlotContents(slot1, destinationStack);
+
+            // Mark the inventory as dirty to ensure changes are saved and synced
+            inventory.markDirty();
+        }
+
+        /**
+         * Consolidate ItemStacks from a source slot to a destination slot in the player's inventory.
+         *
+         * @param inventory       The player's inventory.
+         * @param sourceSlot      The index of the slot to move the item from.
+         * @param destinationSlot The index of the slot to move the item to.
+         */
+        private void consolidateItemStacks(InventoryPlayer inventory, int sourceSlot, int destinationSlot) {
+            ItemStack sourceStack = inventory.getStackInSlot(sourceSlot);
+            ItemStack destinationStack = inventory.getStackInSlot(destinationSlot);
+
+            if (!sourceStack.isItemEqual(destinationStack)
+                    || !ItemStack.areItemStackTagsEqual(sourceStack, destinationStack)) {
+                return;
+            }
+
+            int missingQuantity = destinationStack.getMaxStackSize() - destinationStack.stackSize;
+            if (missingQuantity >= sourceStack.stackSize) {
+                destinationStack.stackSize = destinationStack.stackSize + sourceStack.stackSize;
+                sourceStack = null;
+            } else {
+                sourceStack.stackSize -= missingQuantity;
+                destinationStack.stackSize += missingQuantity;
+            }
+
+            // Update the inventory stacks
+            inventory.setInventorySlotContents(destinationSlot, destinationStack);
+            inventory.setInventorySlotContents(sourceSlot, sourceStack);
+
+            // Mark the inventory as dirty to ensure changes are saved and synced
+            inventory.markDirty();
         }
     }
 }

--- a/src/main/java/com/glodblock/github/network/CPacketSelectBlockWithdraw.java
+++ b/src/main/java/com/glodblock/github/network/CPacketSelectBlockWithdraw.java
@@ -186,13 +186,17 @@ public class CPacketSelectBlockWithdraw implements IMessage {
                 if (itemsToGive != null && itemsToGive.stackSize > 0) {
                     if (consolidatedStack == null) {
                         player.inventory.setInventorySlotContents(nextEmptySlot, itemsToGive);
-                        swapInventorySlots(player.inventory, player.inventory.currentItem, nextEmptySlot);
                     } else {
                         consolidatedStack.stackSize += itemsToGive.stackSize;
-                        swapInventorySlots(player.inventory, player.inventory.currentItem, consolidatedStackSlot);
                     }
+                    player.inventory.markDirty();
                 }
             }
+
+            // Put the target item stack in the player's active slot.
+            int slotToSwap = consolidatedStack == null ? nextEmptySlot : consolidatedStackSlot;
+            swapInventorySlots(player.inventory, player.inventory.currentItem, slotToSwap);
+
             return null; // No reply packet needed
         }
 

--- a/src/main/resources/assets/ae2fc/lang/en_US.lang
+++ b/src/main/resources/assets/ae2fc/lang/en_US.lang
@@ -219,6 +219,7 @@ error.unknown=Unknown
 
 ae2fc.key.OpenTerminal=Open Wireless Universal Terminal
 ae2fc.key.Restock=Toggle Restock
+ae2fc.key.SelectBlock=Select Block
 
 itemGroup.ae2fc=Fluid Craft For AE2
 


### PR DESCRIPTION
I thought that it may be an interesting feature for there to be a creative-like block select keybind that pulled blocks from your AE2 system instead of spawning them in. This is my current proof of concept for the idea.

**Flow:**
1) Press assigned keybinding while looking at a block
2) Checks for a Universal Terminal in the player's inventory and bauble slots
3) Gets the block the player is looking at
4) Checks to see if there is a full stack of the block in their inventory. If so, make it the active slot.
5) Consolidate partial stacks to make a full stack, if a full stack is created make it the active slot.
6) Check that the player is in wireless range of the ae2 network.
7) Withdraw enough items to make a full stack, or as many as possible if not enough available.
8) Put the withdrawn items in the player's active slot.

Additionally, if the full or partial stack is already in the player's hot bar, prioritize not moving the items, and instead move the active slot.

https://github.com/user-attachments/assets/4644dac3-30cb-4148-9427-26a90053e7b5

I'm not sure if this is the correct repo to hold this logic, but there is a dependency on the Universal Terminal and this is just a proof of concept for now. I will be leaving this as a draft for the time being.