### PR TITLE
Fix FluidExportBus NPE

### DIFF
--- a/src/main/java/com/glodblock/github/common/parts/PartFluidExportBus.java
+++ b/src/main/java/com/glodblock/github/common/parts/PartFluidExportBus.java
@@ -112,10 +112,9 @@ public class PartFluidExportBus extends FCSharedFluidBus implements ICraftingReq
         this.didSomething = false;
         this.fluidToSend = this.calculateAmountToSend();
         final TileEntity te = this.getConnectedTE();
-
-        if (te instanceof IFluidHandler) {
+        InventoryAdaptor destination;
+        if (te instanceof IFluidHandler && (destination = this.getHandler(te)) != null) {
             try {
-                final InventoryAdaptor destination = this.getHandler(te);
                 final ICraftingGrid cg = this.getProxy().getCrafting();
                 final IFluidHandler fh = (IFluidHandler) te;
                 final IMEMonitor<IAEFluidStack> inv = this.getProxy().getStorage().getFluidInventory();


### PR DESCRIPTION
1. Install a CraftingCard into a FluidExportBus 
2. Place any panel (e.g. a Storage Bus) in front of FluidExportBus (un-attached to cable)
3. crash

<img width="287" alt="1750744847798" src="https://github.com/user-attachments/assets/d94f84ec-cc65-45b9-a730-2ff3fe74e0e3" />

```
java.lang.NullPointerException: Ticking GridNode
	at appeng.helpers.MultiCraftingTracker.handleCrafting(MultiCraftingTracker.java:68)
	at com.glodblock.github.common.parts.PartFluidExportBus.doBusWork(PartFluidExportBus.java:159)
	at com.glodblock.github.common.parts.PartFluidExportBus.tickingRequest(PartFluidExportBus.java:79)
	at appeng.me.cache.TickManagerCache.onUpdateTick(TickManagerCache.java:77)
	at appeng.me.GridCacheWrapper.onUpdateTick(GridCacheWrapper.java:30)
	at appeng.me.Grid.update(Grid.java:257)
```

It seems that a TE instanceof IFluidHandler might get null for InventoryAdaptor.
The item version of exportbus has no such bug.

