### PR TITLE
Use CraftingID to check CraftingLink equivalence in Level Maintainer

### DIFF
--- a/src/main/java/com/glodblock/github/common/tile/TileLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileLevelMaintainer.java
@@ -137,8 +137,11 @@ public class TileLevelMaintainer extends AENetworkTile
     @Override
     public void jobStateChange(ICraftingLink link) {
         for (int i = 0; i < REQ_COUNT; i++) {
-            if (requests[i] != null && requests[i].link == link) {
-                this.updateLink(i, null);
+            if (requests[i] != null && link != null) {
+                ICraftingLink prevLink = requests[i].link;
+                if (prevLink != null && prevLink.getCraftingID().equals(link.getCraftingID())) {
+                    this.updateLink(i, null);
+                }
             }
         }
     }
@@ -410,10 +413,13 @@ public class TileLevelMaintainer extends AENetworkTile
         return link == null || link.isDone() || link.isCanceled();
     }
 
-    private int getRequestIndexByLink(ICraftingLink link) {
+    private int getRequestIndexByLink(ICraftingLink targetLink) {
         for (int i = 0; i < REQ_COUNT; i++) {
-            if (requests[i] != null && requests[i].link == link) {
-                return i;
+            if (requests[i] != null && targetLink != null) {
+                ICraftingLink link = requests[i].link;
+                if (link != null && link.getCraftingID().equals(targetLink.getCraftingID())) {
+                    return i;
+                }
             }
         }
         return -1;


### PR DESCRIPTION
Myabe fixes https://discord.com/channels/181078474394566657/522098956491030558/1389345166346944562 and https://discord.com/channels/181078474394566657/522098956491030558/1390781200163016830

When a link is loaded from NBT, the instance becomes new, so it is determined to be a different link, which may have prevented the end of crafting from being detected.