### PR TITLE
Refactor: Replace `Ae2Reflect` usages with direct method calls

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -35,10 +35,12 @@
  */
 dependencies {
     api('com.github.GTNewHorizons:NotEnoughItems:2.7.60-GTNH:dev')
-    api('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-656-GTNH:dev')
+    //api('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-656-GTNH:dev')
     api('curse.maven:cofh-core-69162:2388751')
     api('com.github.GTNewHorizons:waila:1.8.10:dev')
     api("com.github.GTNewHorizons:GTNHLib:0.6.34:dev")
+
+    implementation(files("C:\\Users\\colpa\\IdeaProjects\\GTNH-Mods\\Applied-Energistics-2-Unofficial\\build\\libs\\appliedenergistics2-rv3-beta-669-GTNH-AEFC-remove-reflection+e68b9aad07-dirty-dev.jar"))
 
     implementation("com.github.GTNewHorizons:WirelessCraftingTerminal:1.12.6:dev") {
         exclude group: 'com.github.GTNewHorizons', module: 'Applied-Energistics-2-Unofficial'

--- a/src/main/java/com/glodblock/github/client/gui/GuiCraftingStatus.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiCraftingStatus.java
@@ -22,13 +22,11 @@ import com.glodblock.github.util.Ae2ReflectClient;
 
 import appeng.api.storage.ITerminalHost;
 import appeng.api.storage.data.IAEItemStack;
-import appeng.client.gui.widgets.GuiTabButton;
 import appeng.container.AEBaseContainer;
 import appeng.helpers.InventoryAction;
 
 public class GuiCraftingStatus extends appeng.client.gui.implementations.GuiCraftingStatus {
 
-    private GuiTabButton originalGuiBtn;
     private final ITerminalHost host;
 
     public GuiCraftingStatus(InventoryPlayer inventoryPlayer, ITerminalHost te) {
@@ -38,26 +36,21 @@ public class GuiCraftingStatus extends appeng.client.gui.implementations.GuiCraf
 
     @Override
     public void initGui() {
-        if (host instanceof PartFluidPatternTerminal)
-            Ae2ReflectClient.rewriteIcon(this, ItemAndBlockHolder.FLUID_TERMINAL.stack());
-        else if (host instanceof PartFluidPatternTerminalEx)
-            Ae2ReflectClient.rewriteIcon(this, ItemAndBlockHolder.FLUID_TERMINAL_EX.stack());
-        else if (host instanceof PartFluidTerminal)
-            Ae2ReflectClient.rewriteIcon(this, ItemAndBlockHolder.FLUID_TERM.stack());
-        else if (host instanceof PartLevelTerminal)
-            Ae2ReflectClient.rewriteIcon(this, ItemAndBlockHolder.LEVEL_TERMINAL.stack());
+        if (host instanceof PartFluidPatternTerminal) this.myIcon = ItemAndBlockHolder.FLUID_TERMINAL.stack();
+        else if (host instanceof PartFluidPatternTerminalEx) this.myIcon = ItemAndBlockHolder.FLUID_TERMINAL_EX.stack();
+        else if (host instanceof PartFluidTerminal) this.myIcon = ItemAndBlockHolder.FLUID_TERM.stack();
+        else if (host instanceof PartLevelTerminal) this.myIcon = ItemAndBlockHolder.LEVEL_TERMINAL.stack();
         else if (host instanceof IWirelessTerminal terminal && terminal.isUniversal(host))
-            Ae2ReflectClient.rewriteIcon(this, ItemAndBlockHolder.WIRELESS_ULTRA_TERM.stack());
+            this.myIcon = ItemAndBlockHolder.WIRELESS_ULTRA_TERM.stack();
         else if (host instanceof WirelessFluidTerminalInventory)
-            Ae2ReflectClient.rewriteIcon(this, ItemAndBlockHolder.WIRELESS_FLUID_TERM.stack());
+            this.myIcon = ItemAndBlockHolder.WIRELESS_FLUID_TERM.stack();
         else if (host instanceof WirelessPatternTerminalInventory)
-            Ae2ReflectClient.rewriteIcon(this, ItemAndBlockHolder.WIRELESS_PATTERN_TERM.stack());
+            this.myIcon = ItemAndBlockHolder.WIRELESS_PATTERN_TERM.stack();
         else if (host instanceof WirelessInterfaceTerminalInventory)
-            Ae2ReflectClient.rewriteIcon(this, ItemAndBlockHolder.WIRELESS_INTERFACE_TERM.stack());
+            this.myIcon = ItemAndBlockHolder.WIRELESS_INTERFACE_TERM.stack();
         else if (host instanceof WirelessLevelTerminalInventory)
-            Ae2ReflectClient.rewriteIcon(this, ItemAndBlockHolder.WIRELESS_LEVEL_TERM.stack());
+            this.myIcon = ItemAndBlockHolder.WIRELESS_LEVEL_TERM.stack();
         super.initGui();
-        originalGuiBtn = Ae2ReflectClient.getOriginalGuiButton(this);
     }
 
     @Override

--- a/src/main/java/com/glodblock/github/client/gui/base/FCGuiMonitor.java
+++ b/src/main/java/com/glodblock/github/client/gui/base/FCGuiMonitor.java
@@ -501,7 +501,7 @@ public abstract class FCGuiMonitor<T extends IAEStack<T>> extends FCBaseMEGui
                     action = InventoryAction.PICKUP_SINGLE;
                 }
             }
-            if (Ae2ReflectClient.getDragClick(this).size() > 1) {
+            if (this.drag_click.size() > 1) {
                 return;
             }
             final PacketInventoryAction p = new PacketInventoryAction(action, slotIdx, 0);
@@ -552,7 +552,7 @@ public abstract class FCGuiMonitor<T extends IAEStack<T>> extends FCBaseMEGui
         }
 
         if (slot instanceof SlotDisconnected) {
-            if (Ae2ReflectClient.getDragClick(this).size() > 1) {
+            if (this.drag_click.size() > 1) {
                 return;
             }
             InventoryAction action = null;

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidCraftConfirm.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidCraftConfirm.java
@@ -13,11 +13,9 @@ import com.glodblock.github.common.parts.PartLevelTerminal;
 import com.glodblock.github.inventory.InventoryHandler;
 import com.glodblock.github.inventory.gui.GuiType;
 import com.glodblock.github.inventory.item.IWirelessTerminal;
-import com.glodblock.github.util.Ae2Reflect;
 import com.glodblock.github.util.BlockPos;
 
 import appeng.api.networking.IGrid;
-import appeng.api.networking.crafting.ICraftingJob;
 import appeng.api.networking.security.IActionHost;
 import appeng.api.storage.ITerminalHost;
 import appeng.container.implementations.ContainerCraftConfirm;
@@ -71,8 +69,8 @@ public class ContainerFluidCraftConfirm extends ContainerCraftConfirm {
     @Override
     public void optimizePatterns() {
         // only V2 supported
-        IGrid grid = Ae2Reflect.getGrid(this);
-        ICraftingJob result = Ae2Reflect.getResult(this);
+        IGrid grid = this.getGrid();
+
         if (result instanceof CraftingJobV2 && !this.isSimulation()
                 && grid != null
                 && !grid.getMachines(TilePatternOptimizationMatrix.class).isEmpty()) {

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidIO.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidIO.java
@@ -5,7 +5,6 @@ import net.minecraft.entity.player.InventoryPlayer;
 import com.glodblock.github.client.gui.container.base.FCContainerFluidConfigurable;
 import com.glodblock.github.common.parts.PartFluidExportBus;
 import com.glodblock.github.common.parts.base.FCSharedFluidBus;
-import com.glodblock.github.util.Ae2Reflect;
 
 import appeng.api.config.SchedulingMode;
 import appeng.api.config.Settings;
@@ -34,7 +33,7 @@ public class ContainerFluidIO extends FCContainerFluidConfigurable {
     @Override
     protected void loadSettingsFromHost(IConfigManager cm) {
         super.loadSettingsFromHost(cm);
-        if (Ae2Reflect.getUpgradeableHost(this) instanceof PartFluidExportBus) {
+        if (this.getUpgradeable() instanceof PartFluidExportBus) {
             this.setCraftingMode((YesNo) cm.getSetting(Settings.CRAFT_ONLY));
             this.setSchedulingMode((SchedulingMode) cm.getSetting(Settings.SCHEDULING_MODE));
         }

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidLevelEmitter.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidLevelEmitter.java
@@ -7,12 +7,10 @@ import net.minecraft.inventory.IInventory;
 import com.glodblock.github.client.gui.container.base.FCContainerFluidConfigurable;
 import com.glodblock.github.common.parts.PartFluidLevelEmitter;
 import com.glodblock.github.inventory.slot.OptionalFluidSlotFakeTypeOnly;
-import com.glodblock.github.util.Ae2Reflect;
 
 import appeng.api.config.RedstoneMode;
 import appeng.api.config.SecurityPermissions;
 import appeng.api.config.Settings;
-import appeng.api.implementations.IUpgradeableHost;
 import appeng.client.gui.widgets.MEGuiTextField;
 import appeng.container.guisync.GuiSync;
 import appeng.tile.inventory.AppEngInternalAEInventory;
@@ -37,10 +35,6 @@ public class ContainerFluidLevelEmitter extends FCContainerFluidConfigurable {
 
     public PartFluidLevelEmitter getBus() {
         return this.lvlEmitter;
-    }
-
-    protected IUpgradeableHost getUpgradeable() {
-        return Ae2Reflect.getUpgradeableHost(this);
     }
 
     public AppEngInternalAEInventory getFakeFluidInv() {
@@ -84,8 +78,7 @@ public class ContainerFluidLevelEmitter extends FCContainerFluidConfigurable {
         if (Platform.isServer()) {
             this.EmitterValue = this.lvlEmitter.getReportingValue();
             this.setRedStoneMode(
-                    (RedstoneMode) Ae2Reflect.getUpgradeableHost(this).getConfigManager()
-                            .getSetting(Settings.REDSTONE_EMITTER));
+                    (RedstoneMode) this.getUpgradeable().getConfigManager().getSetting(Settings.REDSTONE_EMITTER));
         }
 
         this.standardDetectAndSendChanges();

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidStorageBus.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerFluidStorageBus.java
@@ -9,7 +9,6 @@ import com.glodblock.github.client.gui.container.base.FCContainerFluidConfigurab
 import com.glodblock.github.common.item.ItemFluidPacket;
 import com.glodblock.github.common.parts.PartFluidStorageBus;
 import com.glodblock.github.inventory.slot.OptionalFluidSlotFakeTypeOnly;
-import com.glodblock.github.util.Ae2Reflect;
 
 import appeng.api.AEApi;
 import appeng.api.config.AccessRestriction;
@@ -51,8 +50,8 @@ public class ContainerFluidStorageBus extends FCContainerFluidConfigurable {
     protected void setupConfig() {
         final int xo = 8;
         final int yo = 23 + 6;
-        final IInventory upgrades = Ae2Reflect.getUpgradeList(this).getInventoryByName("upgrades");
-        final IInventory config = Ae2Reflect.getUpgradeList(this).getInventoryByName("config");
+        final IInventory upgrades = getUpgradeable().getInventoryByName("upgrades");
+        final IInventory config = getUpgradeable().getInventoryByName("config");
         for (int y = 0; y < 7; y++) {
             for (int x = 0; x < 9; x++) {
                 this.addSlotToContainer(
@@ -104,7 +103,7 @@ public class ContainerFluidStorageBus extends FCContainerFluidConfigurable {
     @Override
     protected boolean isValidForConfig(int slot, IAEFluidStack fs) {
         if (this.supportCapacity()) {
-            final int upgrades = Ae2Reflect.getUpgradeList(this).getInstalledUpgrades(Upgrades.CAPACITY);
+            final int upgrades = getUpgradeable().getInstalledUpgrades(Upgrades.CAPACITY);
             final int y = slot / 9;
             return y < upgrades + 2;
         }
@@ -126,11 +125,9 @@ public class ContainerFluidStorageBus extends FCContainerFluidConfigurable {
         this.verifyPermissions(SecurityPermissions.BUILD, false);
 
         if (Platform.isServer()) {
-            this.setReadWriteMode(
-                    (AccessRestriction) Ae2Reflect.getUpgradeList(this).getConfigManager().getSetting(Settings.ACCESS));
+            this.setReadWriteMode((AccessRestriction) getUpgradeable().getConfigManager().getSetting(Settings.ACCESS));
             this.setStorageFilter(
-                    (StorageFilter) Ae2Reflect.getUpgradeList(this).getConfigManager()
-                            .getSetting(Settings.STORAGE_FILTER));
+                    (StorageFilter) getUpgradeable().getConfigManager().getSetting(Settings.STORAGE_FILTER));
         }
 
         this.standardDetectAndSendChanges();
@@ -138,8 +135,8 @@ public class ContainerFluidStorageBus extends FCContainerFluidConfigurable {
 
     @Override
     public boolean isSlotEnabled(final int idx) {
-        if (Ae2Reflect.getUpgradeList(this).getInstalledUpgrades(Upgrades.ORE_FILTER) > 0) return false;
-        final int upgrades = Ae2Reflect.getUpgradeList(this).getInstalledUpgrades(Upgrades.CAPACITY);
+        if (getUpgradeable().getInstalledUpgrades(Upgrades.ORE_FILTER) > 0) return false;
+        final int upgrades = getUpgradeable().getInstalledUpgrades(Upgrades.CAPACITY);
         return upgrades > (idx - 2);
     }
 

--- a/src/main/java/com/glodblock/github/client/gui/container/base/FCContainerFluidConfigurable.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/base/FCContainerFluidConfigurable.java
@@ -14,7 +14,6 @@ import com.glodblock.github.FluidCraft;
 import com.glodblock.github.common.item.ItemFluidPacket;
 import com.glodblock.github.inventory.slot.OptionalFluidSlotFakeTypeOnly;
 import com.glodblock.github.network.SPacketFluidUpdate;
-import com.glodblock.github.util.Ae2Reflect;
 import com.glodblock.github.util.Util;
 
 import appeng.api.config.Upgrades;
@@ -64,7 +63,7 @@ public abstract class FCContainerFluidConfigurable extends ContainerUpgradeable 
     protected void setupConfig() {
         this.setupUpgrades();
 
-        final IInventory inv = Ae2Reflect.getUpgradeList(this).getInventoryByName("config");
+        final IInventory inv = getUpgradeable().getInventoryByName("config");
         final int y = 40;
         final int x = 80;
         this.addSlotToContainer(new OptionalFluidSlotFakeTypeOnly(inv, null, this, 0, x, y, 0, 0, 0));
@@ -84,7 +83,7 @@ public abstract class FCContainerFluidConfigurable extends ContainerUpgradeable 
     protected boolean isValidForConfig(int slot, IAEFluidStack fs) {
         if (this.supportCapacity()) {
             // assumes 4 slots per upgrade
-            final int upgrades = Ae2Reflect.getUpgradeList(this).getInstalledUpgrades(Upgrades.CAPACITY);
+            final int upgrades = getUpgradeable().getInstalledUpgrades(Upgrades.CAPACITY);
 
             if (slot > 0 && upgrades < 1) {
                 return false;

--- a/src/main/java/com/glodblock/github/common/item/FCBaseItemCell.java
+++ b/src/main/java/com/glodblock/github/common/item/FCBaseItemCell.java
@@ -145,7 +145,7 @@ public abstract class FCBaseItemCell extends AEBaseItem implements IStorageFluid
                 }
 
                 if (handler.isPreformatted()) {
-                    final String list = (handler.getIncludeExcludeMode() == IncludeExclude.WHITELIST ? GuiText.Included
+                    final String list = (handler.getWhitelist() == IncludeExclude.WHITELIST ? GuiText.Included
                         : GuiText.Excluded).getLocal();
                     lines.add(GuiText.Partitioned.getLocal() + " - " + list + ' ' + GuiText.Precise.getLocal());
 

--- a/src/main/java/com/glodblock/github/common/storage/FluidCellInventory.java
+++ b/src/main/java/com/glodblock/github/common/storage/FluidCellInventory.java
@@ -84,16 +84,15 @@ public class FluidCellInventory implements IFluidCellInventory {
         }
 
         final IInventory upgrades = this.getUpgradesInventory();
+        Upgrades u;
         for (int x = 0; x < upgrades.getSizeInventory(); x++) {
             final ItemStack is = upgrades.getStackInSlot(x);
-            if (is != null && is.getItem() instanceof IUpgradeModule) {
-                final Upgrades u = ((IUpgradeModule) is.getItem()).getType(is);
-                if (u != null) {
-                    switch (u) {
-                        case VOID_OVERFLOW -> cardVoidOverflow = true;
-                        case DISTRIBUTION -> cardDistribution = true;
-                        default -> {}
-                    }
+            if (is == null) continue;
+            if (is.getItem() instanceof IUpgradeModule upgradeItem && (u = upgradeItem.getType(is)) != null) {
+                switch (u) {
+                    case VOID_OVERFLOW -> cardVoidOverflow = true;
+                    case DISTRIBUTION -> cardDistribution = true;
+                    default -> {}
                 }
             }
         }

--- a/src/main/java/com/glodblock/github/common/storage/FluidCellInventoryHandler.java
+++ b/src/main/java/com/glodblock/github/common/storage/FluidCellInventoryHandler.java
@@ -7,7 +7,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
 import com.glodblock.github.common.item.ItemFluidPacket;
-import com.glodblock.github.util.Ae2Reflect;
 import com.glodblock.github.util.Util;
 
 import appeng.api.AEApi;
@@ -78,8 +77,8 @@ public class FluidCellInventoryHandler extends MEInventoryHandler<IAEFluidStack>
     @Override
     public IFluidCellInventory getCellInv() {
         Object o = this.getInternal();
-        if (o instanceof MEPassThrough) {
-            o = Ae2Reflect.getInternal((MEPassThrough<?>) o);
+        if (o instanceof MEPassThrough<?>pt) {
+            o = pt.getInternal();
         }
         return (IFluidCellInventory) (o instanceof IFluidCellInventory ? o : null);
     }
@@ -87,16 +86,22 @@ public class FluidCellInventoryHandler extends MEInventoryHandler<IAEFluidStack>
     @Override
     @SuppressWarnings("unchecked")
     public Iterable<IAEFluidStack> getPartitionInv() {
-        return (Iterable<IAEFluidStack>) Ae2Reflect.getPartitionList(this).getItems();
+        return getPartitionList().getItems();
     }
 
     @Override
     public boolean isPreformatted() {
-        return !Ae2Reflect.getPartitionList(this).isEmpty();
+        return !getPartitionList().isEmpty();
     }
 
     @Override
+    @Deprecated
     public IncludeExclude getIncludeExcludeMode() {
+        return getWhitelist();
+    }
+
+    @Override
+    public IncludeExclude getWhitelist() {
         return IncludeExclude.WHITELIST;
     }
 
@@ -113,11 +118,7 @@ public class FluidCellInventoryHandler extends MEInventoryHandler<IAEFluidStack>
     @Override
     public boolean canGetInv() {
         IFluidCellInventory cellInv = this.getCellInv();
-        if (cellInv instanceof CreativeFluidCellInventory) {
-            return false;
-        } else {
-            return true;
-        }
+        return !(cellInv instanceof CreativeFluidCellInventory);
     }
 
     @Override
@@ -164,7 +165,6 @@ public class FluidCellInventoryHandler extends MEInventoryHandler<IAEFluidStack>
         IFluidCellInventory cellInventory = this.getCellInv();
         if (cellInventory instanceof FluidCellInventory ci) {
             return ci.getRestriction();
-
         }
         return null;
     }

--- a/src/main/java/com/glodblock/github/common/storage/IFluidCellInventoryHandler.java
+++ b/src/main/java/com/glodblock/github/common/storage/IFluidCellInventoryHandler.java
@@ -11,5 +11,9 @@ public interface IFluidCellInventoryHandler {
 
     boolean isPreformatted();
 
+    /** use {@link IFluidCellInventoryHandler#getWhitelist} instead */
+    @Deprecated
     IncludeExclude getIncludeExcludeMode();
+
+    IncludeExclude getWhitelist();
 }

--- a/src/main/java/com/glodblock/github/coremod/hooker/CoreModHooks.java
+++ b/src/main/java/com/glodblock/github/coremod/hooker/CoreModHooks.java
@@ -23,6 +23,7 @@ import com.glodblock.github.util.Ae2Reflect;
 
 import appeng.api.config.Actionable;
 import appeng.api.networking.IGrid;
+import appeng.api.networking.security.MachineSource;
 import appeng.api.networking.storage.IStorageGrid;
 import appeng.api.storage.IMEInventory;
 import appeng.api.storage.IMEInventoryHandler;
@@ -102,7 +103,7 @@ public class CoreModHooks {
     }
 
     public static void storeFluidItem(CraftingCPUCluster instance) {
-        final IGrid g = Ae2Reflect.getGrid(instance);
+        final IGrid g = instance.getGrid();
 
         if (g == null) {
             return;
@@ -111,28 +112,28 @@ public class CoreModHooks {
         final IStorageGrid sg = g.getCache(IStorageGrid.class);
         final IMEInventory<IAEItemStack> ii = sg.getItemInventory();
         final IMEInventory<IAEFluidStack> jj = sg.getFluidInventory();
-        final MECraftingInventory inventory = Ae2Reflect.getCPUInventory(instance);
+        final MECraftingInventory inventory = (MECraftingInventory) instance.getInventory();
 
         for (IAEItemStack is : inventory.getItemList()) {
-            is = inventory.extractItems(is.copy(), Actionable.MODULATE, Ae2Reflect.getCPUSource(instance));
+            is = inventory.extractItems(is.copy(), Actionable.MODULATE, instance.getActionSource());
 
             if (is != null) {
-                Ae2Reflect.postCPUChange(instance, is, Ae2Reflect.getCPUSource(instance));
+                Ae2Reflect.postCPUChange(instance, is, (MachineSource) instance.getActionSource());
                 if (is.getItem() instanceof ItemFluidDrop) {
                     IAEFluidStack fluidDrop = ItemFluidDrop.getAeFluidStack(is);
-                    fluidDrop = jj.injectItems(fluidDrop, Actionable.MODULATE, Ae2Reflect.getCPUSource(instance));
+                    fluidDrop = jj.injectItems(fluidDrop, Actionable.MODULATE, instance.getActionSource());
                     if (fluidDrop == null) {
                         is = null;
                     } else {
                         is.setStackSize(fluidDrop.getStackSize());
                     }
                 } else {
-                    is = ii.injectItems(is, Actionable.MODULATE, Ae2Reflect.getCPUSource(instance));
+                    is = ii.injectItems(is, Actionable.MODULATE, instance.getActionSource());
                 }
             }
 
             if (is != null) {
-                inventory.injectItems(is, Actionable.MODULATE, Ae2Reflect.getCPUSource(instance));
+                inventory.injectItems(is, Actionable.MODULATE, instance.getActionSource());
             }
         }
 
@@ -140,7 +141,7 @@ public class CoreModHooks {
             Ae2Reflect.setCPUInventory(instance, new MECraftingInventory());
         }
 
-        Ae2Reflect.markCPUDirty(instance);
+        instance.markDirty();;
     }
 
     public static ItemStack getStackUnderMouse(GuiContainer gui, int mousex, int mousey) {

--- a/src/main/java/com/glodblock/github/inventory/FluidConvertingInventoryAdaptor.java
+++ b/src/main/java/com/glodblock/github/inventory/FluidConvertingInventoryAdaptor.java
@@ -24,7 +24,6 @@ import com.glodblock.github.common.parts.PartFluidExportBus;
 import com.glodblock.github.common.parts.PartFluidInterface;
 import com.glodblock.github.common.parts.PartFluidP2PInterface;
 import com.glodblock.github.common.tile.TileFluidInterface;
-import com.glodblock.github.util.Ae2Reflect;
 import com.glodblock.github.util.BlockPos;
 import com.glodblock.github.util.ModAndClassUtil;
 import com.glodblock.github.util.Util;
@@ -428,7 +427,7 @@ public class FluidConvertingInventoryAdaptor extends InventoryAdaptor {
                             checkedInput = true;
                         }
                         if (p2p == invFluidsP2P || p2p == null) continue;
-                        IFluidHandler target = Ae2Reflect.getP2PLiquidTarget(p2p);
+                        IFluidHandler target = p2p.getTarget();
                         if (target == null) continue;
                         FluidTankInfo[] info = target.getTankInfo(p2p.getSide().getOpposite());
                         if (info != null) {
@@ -493,8 +492,8 @@ public class FluidConvertingInventoryAdaptor extends InventoryAdaptor {
             DualityInterface other = target.getInterfaceDuality();
             DualityInterface self = this.selfInterface.getInterfaceDuality();
             try {
-                AENetworkProxy proxy1 = Ae2Reflect.getInterfaceProxy(other);
-                AENetworkProxy proxy2 = Ae2Reflect.getInterfaceProxy(self);
+                AENetworkProxy proxy1 = other.getProxy();
+                AENetworkProxy proxy2 = self.getProxy();
                 if (proxy1.getGrid() == proxy2.getGrid()) {
                     return false;
                 }
@@ -528,7 +527,7 @@ public class FluidConvertingInventoryAdaptor extends InventoryAdaptor {
                 ItemSlot slot = new ItemSlot();
                 slot.setSlot(nextSlotIndex++);
                 slot.setItemStack(fluid != null ? ItemFluidPacket.newStack(fluid) : null);
-                Ae2Reflect.setItemSlotExtractable(slot, false);
+                slot.setExtractable(false);
                 return slot;
             } else {
                 ItemSlot slot = itemSlots.next();

--- a/src/main/java/com/glodblock/github/util/Ae2Reflect.java
+++ b/src/main/java/com/glodblock/github/util/Ae2Reflect.java
@@ -116,14 +116,17 @@ public class Ae2Reflect {
         }
     }
 
+    @Deprecated
     public static IPartitionList<?> getPartitionList(MEInventoryHandler<?> me) {
         return Ae2Reflect.readField(me, fAEInv_partitionList);
     }
 
+    @Deprecated
     public static IMEInventory<?> getInternal(MEPassThrough<?> me) {
         return Ae2Reflect.readField(me, fAEPass_internal);
     }
 
+    @Deprecated
     public static void setItemSlotExtractable(ItemSlot slot, boolean extractable) {
         try {
             mItemSlot_setExtractable.invoke(slot, extractable);
@@ -132,26 +135,32 @@ public class Ae2Reflect {
         }
     }
 
+    @Deprecated
     public static ICraftingCPU getCPU(CraftingCPURecord cpu) {
         return Ae2Reflect.readField(cpu, fCPU_cpu);
     }
 
+    @Deprecated
     public static String getName(CraftingCPURecord cpu) {
         return Ae2Reflect.readField(cpu, fCPU_myName);
     }
 
+    @Deprecated
     public static int getProcessors(CraftingCPURecord cpu) {
         return Ae2Reflect.readField(cpu, fCPU_processors);
     }
 
+    @Deprecated
     public static long getSize(CraftingCPURecord cpu) {
         return Ae2Reflect.readField(cpu, fCPU_size);
     }
 
+    @Deprecated
     public static IUpgradeableHost getUpgradeList(ContainerUpgradeable container) {
         return Ae2Reflect.readField(container, fInventory_containerUpgrade);
     }
 
+    @Deprecated
     public static IGrid getGrid(CraftingCPUCluster cpu) {
         try {
             return (IGrid) mCPU_getGrid.invoke(cpu);
@@ -160,6 +169,7 @@ public class Ae2Reflect {
         }
     }
 
+    @Deprecated
     public static IGrid getGrid(ContainerCraftConfirm ccc) {
         try {
             return (IGrid) mCraftConfirm_getGrid.invoke(ccc);
@@ -168,10 +178,12 @@ public class Ae2Reflect {
         }
     }
 
+    @Deprecated
     public static ICraftingJob getResult(ContainerCraftConfirm ccc) {
         return Ae2Reflect.readField(ccc, fCraftConfirm_result);
     }
 
+    @Deprecated
     public static MECraftingInventory getCPUInventory(CraftingCPUCluster cpu) {
         return Ae2Reflect.readField(cpu, fCPU_inventory);
     }
@@ -180,14 +192,17 @@ public class Ae2Reflect {
         Ae2Reflect.writeField(cpu, fCPU_inventory, value);
     }
 
+    @Deprecated
     public static MachineSource getCPUSource(CraftingCPUCluster cpu) {
         return Ae2Reflect.readField(cpu, fCPU_machineSrc);
     }
 
+    @Deprecated
     public static IUpgradeableHost getUpgradeableHost(ContainerUpgradeable owner) {
         return Ae2Reflect.readField(owner, fContainerUpgradeable_upgradeable);
     }
 
+    @Deprecated
     public static AENetworkProxy getInterfaceProxy(DualityInterface owner) {
         return Ae2Reflect.readField(owner, fDualInterface_gridProxy);
     }
@@ -200,6 +215,7 @@ public class Ae2Reflect {
         }
     }
 
+    @Deprecated
     public static void markCPUDirty(CraftingCPUCluster cpu) {
         try {
             mCPU_markDirty.invoke(cpu);
@@ -208,6 +224,7 @@ public class Ae2Reflect {
         }
     }
 
+    @Deprecated
     public static IFluidHandler getP2PLiquidTarget(PartP2PLiquids p2p) {
         try {
             return (IFluidHandler) mP2PLiquids_getTarget.invoke(p2p);

--- a/src/main/java/com/glodblock/github/util/Ae2ReflectClient.java
+++ b/src/main/java/com/glodblock/github/util/Ae2ReflectClient.java
@@ -45,18 +45,22 @@ public class Ae2ReflectClient {
         }
     }
 
+    @Deprecated
     public static void rewriteIcon(GuiCraftingStatus gui, ItemStack icon) {
         Ae2Reflect.writeField(gui, fGuiCPUStatus_icon, icon);
     }
 
+    @Deprecated
     public static Set<Slot> getDragClick(AEBaseGui gui) {
         return Ae2Reflect.readField(gui, fGui_drag);
     }
 
+    @Deprecated
     public static AppEngRenderItem getStackSizeRenderer(AEBaseGui gui) {
         return Ae2Reflect.readField(gui, fAEBaseGui_stackSizeRenderer);
     }
 
+    @Deprecated
     public static GuiTabButton getOriginalGuiButton(GuiCraftingStatus gui) {
         return Ae2Reflect.readField(gui, fGuiCraftingStatus_originalGuiBtn);
     }

--- a/src/main/java/com/glodblock/github/util/Util.java
+++ b/src/main/java/com/glodblock/github/util/Util.java
@@ -281,28 +281,28 @@ public final class Util {
     }
 
     public static FluidStack getFluidFromItem(ItemStack stack) {
-        if (stack != null) {
-            FluidStack fluid = null;
+        if (stack == null) return null;
 
-            if (stack.getItem() instanceof IFluidContainerItem) {
-                fluid = ((IFluidContainerItem) stack.getItem()).getFluid(stack);
-            } else if (FluidContainerRegistry.isContainer(stack)) {
-                fluid = FluidContainerRegistry.getFluidForFilledItem(stack);
-            } else if (stack.getItem() instanceof ItemFluidPacket) {
-                fluid = ItemFluidPacket.getFluidStack(stack);
-            } else if (stack.getItem() instanceof ItemFluidDrop) {
-                fluid = ItemFluidDrop.getFluidStack(Util.copyStackWithSize(stack, 1));
-            }
+        FluidStack fluid = null;
 
-            if (fluid == null) {
-                fluid = StackInfo.getFluid(Util.copyStackWithSize(stack, 1));
-            }
+        if (stack.getItem() instanceof IFluidContainerItem) {
+            fluid = ((IFluidContainerItem) stack.getItem()).getFluid(stack);
+        } else if (FluidContainerRegistry.isContainer(stack)) {
+            fluid = FluidContainerRegistry.getFluidForFilledItem(stack);
+        } else if (stack.getItem() instanceof ItemFluidPacket) {
+            fluid = ItemFluidPacket.getFluidStack(stack);
+        } else if (stack.getItem() instanceof ItemFluidDrop) {
+            fluid = ItemFluidDrop.getFluidStack(Util.copyStackWithSize(stack, 1));
+        }
 
-            if (fluid != null) {
-                FluidStack fluid0 = fluid.copy();
-                fluid0.amount *= stack.stackSize;
-                return fluid0;
-            }
+        if (fluid == null) {
+            fluid = StackInfo.getFluid(Util.copyStackWithSize(stack, 1));
+        }
+
+        if (fluid != null) {
+            FluidStack fluid0 = fluid.copy();
+            fluid0.amount *= stack.stackSize;
+            return fluid0;
         }
         return null;
     }


### PR DESCRIPTION
first we must merge

some are not removed so as not to expose critical parts of the class