### PR TITLE
Disable hotbar keys handling in terminals

### DIFF
--- a/src/main/java/com/glodblock/github/client/gui/base/FCBaseMEGui.java
+++ b/src/main/java/com/glodblock/github/client/gui/base/FCBaseMEGui.java
@@ -262,4 +262,11 @@ public abstract class FCBaseMEGui extends AEBaseMEGui {
     protected boolean isPortableCell() {
         return false;
     }
+
+    // Moving items via hotbar keys in terminals isn't working anyway.
+    // Let's disable hotbar keys processing to allow proper input of numbers in the search field
+    @Override
+    protected boolean checkHotbarKeys(int keyCode) {
+        return false;
+    }
 }


### PR DESCRIPTION
Moving items via hotbar keys from AE2 terminals isn't working anyway. (or I can't figure out how to actually use this).
Let's disable hotbar keys processing to allow proper input of numbers in the search field.

Before: hovering over an item in terminal and pressing 1-9 do nothing
After: it inserts number into search bar if it focused

Related to https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/825