### PR TITLE
Show pattern output recipe/usage when pressing R/U on encoded pattern

### DIFF
--- a/src/main/java/com/glodblock/github/nei/FCEncodedPatternStringifyHandler.java
+++ b/src/main/java/com/glodblock/github/nei/FCEncodedPatternStringifyHandler.java
@@ -1,0 +1,36 @@
+package com.glodblock.github.nei;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+
+import com.glodblock.github.common.item.ItemFluidEncodedPattern;
+
+import codechicken.nei.api.IStackStringifyHandler;
+import codechicken.nei.recipe.stackinfo.DefaultStackStringifyHandler;
+import codechicken.nei.recipe.stackinfo.GTFluidStackStringifyHandler;
+
+public class FCEncodedPatternStringifyHandler implements IStackStringifyHandler {
+
+    private static final DefaultStackStringifyHandler defaultStackStringifyHandler = new DefaultStackStringifyHandler();
+    private static final GTFluidStackStringifyHandler gtFluidStackStringifyHandler = new GTFluidStackStringifyHandler();
+
+    public NBTTagCompound convertItemStackToNBT(ItemStack stack, boolean saveStackSize) {
+        if (!(stack.getItem() instanceof ItemFluidEncodedPattern pattern)) {
+            return null;
+        }
+
+        stack = pattern.getOutput(stack);
+
+        if (stack == null) {
+            return null;
+        }
+
+        NBTTagCompound fluidNbtTag = gtFluidStackStringifyHandler.convertItemStackToNBT(stack, saveStackSize);
+
+        if (fluidNbtTag != null) {
+            return fluidNbtTag;
+        }
+
+        return defaultStackStringifyHandler.convertItemStackToNBT(stack, saveStackSize);
+    }
+}

--- a/src/main/java/com/glodblock/github/nei/NEI_FC_Config.java
+++ b/src/main/java/com/glodblock/github/nei/NEI_FC_Config.java
@@ -11,6 +11,7 @@ import com.glodblock.github.util.ModAndClassUtil;
 
 import codechicken.nei.api.API;
 import codechicken.nei.api.IConfigureNEI;
+import codechicken.nei.recipe.StackInfo;
 
 @SuppressWarnings("unused")
 public class NEI_FC_Config implements IConfigureNEI {
@@ -21,6 +22,8 @@ public class NEI_FC_Config implements IConfigureNEI {
         API.addSearchProvider(new NEISearchFilter());
         API.registerStackStringifyHandler(new FCStackStringifyHandler());
         API.registerUsageHandler(new NEICellViewHandler());
+
+        StackInfo.stackStringifyHandlers.add(new FCEncodedPatternStringifyHandler());
 
         if (ModAndClassUtil.AVARITIA) {
             API.registerGuiOverlay(GuiFluidPatternWireless.class, "extreme", null);


### PR DESCRIPTION
Make pressing R/U shows the recipe/usage of actual item which will be produced it this encoded pattern (first of it, which got displayed, if there is a more then one).

Should at least partially address https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19318

Companion of https://github.com/GTNewHorizons/Applied-Energistics-2-Unofficial/pull/848