### PR TITLE
fix: correct error in TileFluidPacketDecoder closeInventory

### DIFF
--- a/src/main/java/com/glodblock/github/common/tile/TileFluidPacketDecoder.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileFluidPacketDecoder.java
@@ -162,7 +162,7 @@ public class TileFluidPacketDecoder extends AENetworkTile
 
     @Override
     public void closeInventory() {
-        inventory.openInventory();
+        inventory.closeInventory();
     }
 
     @Override


### PR DESCRIPTION
Description:
In TileFluidPacketDecoder.java, the closeInventory() method incorrectly calls inventory.openInventory(). This is a classic copy-paste error that causes the viewer count to increment incorrectly when the GUI is closed.
﻿
Changes:
Changed inventory.openInventory(); to inventory.closeInventory(); inside the closeInventory() override.