### PR TITLE
fix: ensure fluid packets drop when part is broken

### DIFF
--- a/src/main/java/com/glodblock/github/common/parts/PartFluidInterface.java
+++ b/src/main/java/com/glodblock/github/common/parts/PartFluidInterface.java
@@ -51,6 +51,12 @@ public class PartFluidInterface extends PartInterface implements IDualHost, ICus
         this.customButtonDataObject = new FluidInterfaceButtons(false);
     }
 
+    @Override
+    public void getDrops(final List<ItemStack> drops, final boolean wrenched) {
+        this.fluidDuality.addDrops(drops);
+        super.getDrops(drops, wrenched);
+    }
+
     @MENetworkEventSubscribe
     public void stateChange(final MENetworkChannelsChanged c) {
         fluidDuality.onChannelStateChange(c);

--- a/src/main/java/com/glodblock/github/common/parts/PartFluidP2PInterface.java
+++ b/src/main/java/com/glodblock/github/common/parts/PartFluidP2PInterface.java
@@ -52,6 +52,12 @@ public class PartFluidP2PInterface extends PartP2PInterface implements IDualHost
     }
 
     @Override
+    public void getDrops(final List<ItemStack> drops, final boolean wrenched) {
+        this.dualityFluid.addDrops(drops);
+        super.getDrops(drops, wrenched);
+    }
+
+    @Override
     @SideOnly(Side.CLIENT)
     public IIcon getTypeTexture() {
         return ItemAndBlockHolder.INTERFACE.getBlockTextureFromSide(0);


### PR DESCRIPTION
#### **Summary**
Implemented the `getDrops` override for `PartFluidInterface` and `PartFluidP2PInterface` to ensure that any contained fluid packets are correctly dropped when the part is removed or wrenched.

#### **The Issue**
The `PartFluidInterface` and `PartFluidP2PInterface` lacked the `getDrops` override to delegate the dropping logic to its internal duality handler. Consequently, any fluid packets stored within the interface panel were deleted when the part was wrenched or broken. 

#### **The Fix**
- Overrode the `getDrops` method in both fluid interface part classes.
- Explicitly called `this.fluidDuality.addDrops(drops)` to delegate the item dropping logic to the duality handler.
- Called `super.getDrops` to maintain standard AE2 part drop behavior.