### PR TITLE
Load walrus model only once

### DIFF
--- a/src/main/java/com/glodblock/github/client/render/ItemWalrusRender.java
+++ b/src/main/java/com/glodblock/github/client/render/ItemWalrusRender.java
@@ -6,20 +6,18 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.IItemRenderer;
 import net.minecraftforge.client.MinecraftForgeClient;
-import net.minecraftforge.client.model.AdvancedModelLoader;
-import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
 
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.common.tile.TileWalrus;
 import com.glodblock.github.loader.ItemAndBlockHolder;
+import com.glodblock.github.proxy.ClientProxy;
 
 import cpw.mods.fml.client.registry.ClientRegistry;
 
 public class ItemWalrusRender implements IItemRenderer {
 
-    IModelCustom modelWalrus = AdvancedModelLoader.loadModel(FluidCraft.resource("models/walrus.obj"));
     ResourceLocation textureWalrus = FluidCraft.resource("textures/blocks/walrus.png");
 
     public ItemWalrusRender() {
@@ -44,7 +42,7 @@ public class ItemWalrusRender implements IItemRenderer {
             case INVENTORY -> GL11.glTranslatef(-0.5F, -0.5F, -0.1F);
             default -> {}
         }
-        this.modelWalrus.renderAll();
+        ClientProxy.getWalrusModel().renderAll();
         GL11.glPopMatrix();
     }
 

--- a/src/main/java/com/glodblock/github/client/render/RenderBlockWalrus.java
+++ b/src/main/java/com/glodblock/github/client/render/RenderBlockWalrus.java
@@ -4,17 +4,15 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.client.model.AdvancedModelLoader;
-import net.minecraftforge.client.model.IModelCustom;
 
 import org.lwjgl.opengl.GL11;
 
 import com.glodblock.github.FluidCraft;
 import com.glodblock.github.common.tile.TileWalrus;
+import com.glodblock.github.proxy.ClientProxy;
 
 public class RenderBlockWalrus extends TileEntitySpecialRenderer {
 
-    IModelCustom modelWalrus = AdvancedModelLoader.loadModel(FluidCraft.resource("models/walrus.obj"));
     ResourceLocation textureWalrus = FluidCraft.resource("textures/blocks/walrus.png");
 
     @Override
@@ -42,7 +40,7 @@ public class RenderBlockWalrus extends TileEntitySpecialRenderer {
                 break;
         }
         GL11.glScalef(scale, scale, scale);
-        this.modelWalrus.renderAll();
+        ClientProxy.getWalrusModel().renderAll();
         GL11.glPopMatrix();
     }
 }

--- a/src/main/java/com/glodblock/github/proxy/ClientProxy.java
+++ b/src/main/java/com/glodblock/github/proxy/ClientProxy.java
@@ -4,6 +4,8 @@ import static com.glodblock.github.common.Config.reStockTime;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.client.model.AdvancedModelLoader;
+import net.minecraftforge.client.model.IModelCustom;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
@@ -27,6 +29,7 @@ public class ClientProxy extends CommonProxy {
 
     private static final Minecraft mc = Minecraft.getMinecraft();
     private static long refreshTick = System.currentTimeMillis();
+    private static IModelCustom modelWalrus;
 
     @Override
     public void preInit(FMLPreInitializationEvent event) {
@@ -39,6 +42,7 @@ public class ClientProxy extends CommonProxy {
         (new ListenerLoader()).run();
         (new RenderLoader()).run();
         (new KeybindLoader()).run();
+        modelWalrus = AdvancedModelLoader.loadModel(FluidCraft.resource("models/walrus.obj"));
     }
 
     @Override
@@ -64,5 +68,9 @@ public class ClientProxy extends CommonProxy {
             }
             refreshTick = System.currentTimeMillis();
         }
+    }
+
+    public static IModelCustom getWalrusModel() {
+        return modelWalrus;
     }
 }


### PR DESCRIPTION
loading big rendering model takes space in memory so doing it once is better
<img width="738" height="407" alt="image" src="https://github.com/user-attachments/assets/b0c54776-1e77-482b-b780-4100cd8330cc" />
