### PR TITLE
Fix item config blocking fluid interface

### DIFF
--- a/src/main/java/com/glodblock/github/common/parts/PartFluidInterface.java
+++ b/src/main/java/com/glodblock/github/common/parts/PartFluidInterface.java
@@ -1,7 +1,12 @@
 package com.glodblock.github.common.parts;
 
+import static appeng.util.item.AEFluidStackType.FLUID_STACK_TYPE;
+import static appeng.util.item.AEItemStackType.ITEM_STACK_TYPE;
+
 import java.io.IOException;
 import java.util.List;
+
+import javax.annotation.Nullable;
 
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.item.ItemStack;
@@ -10,6 +15,8 @@ import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
+
+import org.jetbrains.annotations.NotNull;
 
 import com.glodblock.github.client.FluidInterfaceButtons;
 import com.glodblock.github.common.item.ItemFluidPacket;
@@ -29,6 +36,7 @@ import appeng.api.networking.ticking.TickRateModulation;
 import appeng.api.networking.ticking.TickingRequest;
 import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.data.IAEFluidStack;
+import appeng.api.storage.data.IAEStackType;
 import appeng.helpers.ICustomButtonDataObject;
 import appeng.helpers.ICustomButtonProvider;
 import appeng.parts.misc.PartInterface;
@@ -88,6 +96,18 @@ public class PartFluidInterface extends PartInterface implements IDualHost, ICus
     @Override
     public IMEMonitor<IAEFluidStack> getFluidInventory() {
         return this.fluidDuality.getFluidInventory();
+    }
+
+    @Override
+    @Nullable
+    public IMEMonitor<?> getMEMonitor(@NotNull IAEStackType<?> type) {
+        if (type == ITEM_STACK_TYPE) {
+            return this.getItemInventory();
+        } else if (type == FLUID_STACK_TYPE) {
+            return this.getFluidInventory();
+        }
+
+        return this.fluidDuality.getMEMonitor(type);
     }
 
     @Override

--- a/src/main/java/com/glodblock/github/common/parts/PartFluidP2PInterface.java
+++ b/src/main/java/com/glodblock/github/common/parts/PartFluidP2PInterface.java
@@ -1,8 +1,12 @@
 package com.glodblock.github.common.parts;
 
+import static appeng.util.item.AEFluidStackType.FLUID_STACK_TYPE;
+import static appeng.util.item.AEItemStackType.ITEM_STACK_TYPE;
+
 import java.util.List;
 
-import appeng.api.storage.data.IAEStackType;
+import javax.annotation.Nullable;
+
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -12,6 +16,8 @@ import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
+
+import org.jetbrains.annotations.NotNull;
 
 import com.glodblock.github.client.FluidInterfaceButtons;
 import com.glodblock.github.common.item.ItemFluidPacket;
@@ -28,6 +34,7 @@ import appeng.api.networking.ticking.TickRateModulation;
 import appeng.api.networking.ticking.TickingRequest;
 import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.data.IAEFluidStack;
+import appeng.api.storage.data.IAEStackType;
 import appeng.api.util.IConfigManager;
 import appeng.helpers.DualityInterface;
 import appeng.helpers.ICustomButtonDataObject;
@@ -38,12 +45,6 @@ import appeng.tile.inventory.AppEngInternalAEInventory;
 import appeng.util.Platform;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import org.jetbrains.annotations.NotNull;
-
-import javax.annotation.Nullable;
-
-import static appeng.util.item.AEFluidStackType.FLUID_STACK_TYPE;
-import static appeng.util.item.AEItemStackType.ITEM_STACK_TYPE;
 
 public class PartFluidP2PInterface extends PartP2PInterface implements IDualHost, ICustomButtonProvider {
 

--- a/src/main/java/com/glodblock/github/common/parts/PartFluidP2PInterface.java
+++ b/src/main/java/com/glodblock/github/common/parts/PartFluidP2PInterface.java
@@ -2,6 +2,7 @@ package com.glodblock.github.common.parts;
 
 import java.util.List;
 
+import appeng.api.storage.data.IAEStackType;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -37,6 +38,12 @@ import appeng.tile.inventory.AppEngInternalAEInventory;
 import appeng.util.Platform;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nullable;
+
+import static appeng.util.item.AEFluidStackType.FLUID_STACK_TYPE;
+import static appeng.util.item.AEItemStackType.ITEM_STACK_TYPE;
 
 public class PartFluidP2PInterface extends PartP2PInterface implements IDualHost, ICustomButtonProvider {
 
@@ -157,6 +164,18 @@ public class PartFluidP2PInterface extends PartP2PInterface implements IDualHost
     @Override
     public IMEMonitor<IAEFluidStack> getFluidInventory() {
         return this.dualityFluid.getFluidInventory();
+    }
+
+    @Override
+    @Nullable
+    public IMEMonitor<?> getMEMonitor(@NotNull IAEStackType<?> type) {
+        if (type == ITEM_STACK_TYPE) {
+            return this.getItemInventory();
+        } else if (type == FLUID_STACK_TYPE) {
+            return this.getFluidInventory();
+        }
+
+        return this.dualityFluid.getMEMonitor(type);
     }
 
     @Override

--- a/src/main/java/com/glodblock/github/common/tile/TileFluidInterface.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileFluidInterface.java
@@ -1,5 +1,8 @@
 package com.glodblock.github.common.tile;
 
+import static appeng.util.item.AEFluidStackType.FLUID_STACK_TYPE;
+import static appeng.util.item.AEItemStackType.ITEM_STACK_TYPE;
+
 import java.io.IOException;
 import java.util.List;
 
@@ -13,6 +16,8 @@ import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
+
+import org.jetbrains.annotations.NotNull;
 
 import com.glodblock.github.client.FluidInterfaceButtons;
 import com.glodblock.github.common.item.ItemFluidPacket;
@@ -34,6 +39,7 @@ import appeng.api.networking.ticking.TickRateModulation;
 import appeng.api.networking.ticking.TickingRequest;
 import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.data.IAEFluidStack;
+import appeng.api.storage.data.IAEStackType;
 import appeng.api.util.IConfigManager;
 import appeng.helpers.ICustomButtonDataObject;
 import appeng.helpers.ICustomButtonProvider;
@@ -108,6 +114,18 @@ public class TileFluidInterface extends TileInterface implements IDualHost, ICus
     public AppEngInternalAEInventory getConfig() {
         Util.mirrorFluidToPacket(this.config, fluidDuality.getConfig());
         return config;
+    }
+
+    @Override
+    @Nullable
+    public IMEMonitor<?> getMEMonitor(@NotNull IAEStackType<?> type) {
+        if (type == ITEM_STACK_TYPE) {
+            return this.getItemInventory();
+        } else if (type == FLUID_STACK_TYPE) {
+            return this.getFluidInventory();
+        }
+
+        return this.fluidDuality.getMEMonitor(type);
     }
 
     @Override


### PR DESCRIPTION
Default behavior of TileInterface and PartInterface caused the dual interface to not return any fluids when the item config was enabled. And also to return only the other network's fluids instead of internal ones if fluid config was set. This pr fixes that.