### PR TITLE
Make Fluid Cells storable in Item Cells again

### DIFF
--- a/src/main/java/com/glodblock/github/common/item/FCBaseItemCell.java
+++ b/src/main/java/com/glodblock/github/common/item/FCBaseItemCell.java
@@ -12,6 +12,7 @@ import com.google.common.base.Optional;
 
 import appeng.api.storage.data.IAEStackType;
 import appeng.items.AEBaseCell;
+import cpw.mods.fml.common.Loader;
 
 public abstract class FCBaseItemCell extends AEBaseCell {
 
@@ -49,5 +50,12 @@ public abstract class FCBaseItemCell extends AEBaseCell {
 
     public ItemStack stack() {
         return new ItemStack(this, 1);
+    }
+
+    @Override
+    public boolean storableInStorageCell() {
+
+        // Loader.isModLoaded uses ModID!
+        return Loader.isModLoaded("hodgepodge");
     }
 }

--- a/src/main/java/com/glodblock/github/common/item/FCBaseItemCell.java
+++ b/src/main/java/com/glodblock/github/common/item/FCBaseItemCell.java
@@ -12,7 +12,6 @@ import com.google.common.base.Optional;
 
 import appeng.api.storage.data.IAEStackType;
 import appeng.items.AEBaseCell;
-import cpw.mods.fml.common.Loader;
 
 public abstract class FCBaseItemCell extends AEBaseCell {
 
@@ -54,8 +53,6 @@ public abstract class FCBaseItemCell extends AEBaseCell {
 
     @Override
     public boolean storableInStorageCell() {
-
-        // Loader.isModLoaded uses ModID!
-        return Loader.isModLoaded("hodgepodge");
+        return true;
     }
 }


### PR DESCRIPTION
Storing fluid cells that contain fluid in item cells is vital to a Universal automation I made last year prior to the native fluid changes. Following those changes, most of the automation broke. As a compromise to have this automation as a viable playstyle again, this change makes it so that fluid cells that contain fluid can be stored in item cells. ~~only be stored in item cells if hodgepodge is loaded along with AE2FC.~~