### PR TITLE
Included stationary lava and water to annihilation plane

### DIFF
--- a/src/main/java/com/glodblock/github/common/parts/PartFluidAnnihilationPlane.java
+++ b/src/main/java/com/glodblock/github/common/parts/PartFluidAnnihilationPlane.java
@@ -61,14 +61,14 @@ public class PartFluidAnnihilationPlane extends PartBaseAnnihilationPlane {
             Platform.poweredInsert(power, monitor, toInject, src, Actionable.MODULATE);
             block.drain(world, self.x + side.offsetX, self.y + side.offsetY, self.z + side.offsetZ, true);
         } else if (meta == 0) {
-            if (fluidBlock == Blocks.flowing_water) {
+            if (fluidBlock == Blocks.flowing_water || fluidBlock == Blocks.water) {
                 final IAEFluidStack toInject = Util.FluidUtil.createAEFluidStack(FluidRegistry.WATER);
                 final IAEFluidStack notInjected = Platform
                         .poweredInsert(power, monitor, toInject, src, Actionable.SIMULATE);
                 if (notInjected != null) return;
                 Platform.poweredInsert(power, monitor, toInject, src, Actionable.MODULATE);
                 world.setBlockToAir(self.x + side.offsetX, self.y + side.offsetY, self.z + side.offsetZ);
-            } else if (fluidBlock == Blocks.flowing_lava) {
+            } else if (fluidBlock == Blocks.flowing_lava || fluidBlock == Blocks.lava) {
                 final IAEFluidStack toInject = Util.FluidUtil.createAEFluidStack(FluidRegistry.LAVA);
                 final IAEFluidStack notInjected = Platform
                         .poweredInsert(power, monitor, toInject, src, Actionable.SIMULATE);


### PR DESCRIPTION
Fixes GTNewHorizons/GT-New-Horizons-Modpack#25451

Allows Fluid Annihilation Planes to also collect stationary fluids.

May also fix this issue if blood magic's rituals did not place stationary liquids, LMK if changing that would be more suitable.