### PR TITLE
Fixed grammar on fluid packet tooltip

### DIFF
--- a/src/main/resources/assets/ae2fc/lang/en_US.lang
+++ b/src/main/resources/assets/ae2fc/lang/en_US.lang
@@ -124,7 +124,7 @@ ae2fc.tooltip.cell_portable=Right click to open its GUI. It works like a backpac
 ae2fc.tooltip.fluid_terminal=uh So we don't need EC2 anymore?
 ae2fc.tooltip.level_terminal=uh...
 ae2fc.tooltip.invalid_fluid=Invalid fluid!
-ae2fc.tooltip.item_fluid_packet=§cIf you unexpect this, then you using §6Interface§c instead of §6Dual Interface
+ae2fc.tooltip.item_fluid_packet=§cIf you didn't expect this, then you are using an §6Interface§c instead of a §6Dual Interface
 ae2fc.tooltip.encode_pattern=Encode Pattern
 ae2fc.tooltip.fluid_packet=Use a Fluid Packet/Drops Decoder to\nconvert this back into fluid.
 ae2fc.tooltip.empty=Empty
@@ -175,7 +175,7 @@ ae2fc.tooltip.restock.on.hint=Enable
 ae2fc.tooltip.restock.off=Toggle Restock
 ae2fc.tooltip.restock.off.hint=Disable
 ae2fc.tooltip.Full-stock.mode=Full-stock Mode
-ae2fc.tooltip.Full-stock.mode.hint=Stocked items and fluids always visible to storage busses and only after all are fully stocked following the replenisher being fully emptied, and always fully restocked 
+ae2fc.tooltip.Full-stock.mode.hint=Stocked items and fluids always visible to storage busses and only after all are fully stocked following the replenisher being fully emptied, and always fully restocked
 ae2fc.tooltip.Normal.mode=Normal Mode
 ae2fc.tooltip.Normal.mode.hint=Stocked items and fluids always visible to storage busses, and only restocked when below 50%
 


### PR DESCRIPTION
Fixes incorrect grammar on fluid packet tooltip

Didn't test in game but it's literally just the text so it should be fine