### PR TITLE
Fix universal terminal mode sync in baubles

### DIFF
--- a/src/main/java/com/glodblock/github/client/UltraTerminalButtons.java
+++ b/src/main/java/com/glodblock/github/client/UltraTerminalButtons.java
@@ -230,6 +230,7 @@ public class UltraTerminalButtons implements ICustomButtonDataObject {
         this.reStock = buf.readBoolean();
         this.magnetMode = WirelessMagnet.Mode.values()[buf.readInt()];
         this.terminalMode = UltraTerminalModes.values()[buf.readInt()];
+        ItemWirelessUltraTerminal.setMode(this.terminal, this.terminalMode);
 
         toggleMagnetButtonsVisibility();
         toggleRestockVisibility();


### PR DESCRIPTION
## What changed

- Update the client-side Universal Wireless Terminal mode when receiving the authoritative terminal state from the server.

## Why

When a Universal Wireless Terminal in a Baubles slot was switched to the Interface Terminal and then closed, its mode NBT could remain stale on the client.

Reopening the terminal caused the server to request the Interface Terminal while the client constructed a GUI object for its outdated mode. The GUI type check then failed and displayed an empty GUI with only NEI visible.

Applying the synchronized mode to the client-side terminal keeps both logical sides consistent and allows the terminal to reopen normally.

Fixes GTNewHorizons/GT-New-Horizons-Modpack#25828

## Checklist

- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
