### PR TITLE
Fix ME Fluid Interface not requesting crafting for missing fluids

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -35,7 +35,7 @@
  */
 dependencies {
     api('com.github.GTNewHorizons:NotEnoughItems:2.8.117-GTNH:dev')
-    api('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-999-GTNH:dev')
+    api('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-1024-GTNH:dev')
     api('com.github.GTNewHorizons:waila:1.19.31:dev')
     api("com.github.GTNewHorizons:GTNHLib:0.11.33:dev")
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -34,17 +34,17 @@
  * For more details, see https://docs.gradle.org/8.0.1/userguide/java_library_plugin.html#sec:java_library_configurations_graph
  */
 dependencies {
-    api('com.github.GTNewHorizons:NotEnoughItems:2.8.114-GTNH:dev')
+    api('com.github.GTNewHorizons:NotEnoughItems:2.8.117-GTNH:dev')
     api('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-999-GTNH:dev')
     api('com.github.GTNewHorizons:waila:1.19.31:dev')
-    api("com.github.GTNewHorizons:GTNHLib:0.11.30:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.11.33:dev")
 
     compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.2.21-GTNH:dev')
-    compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.61:dev') {transitive = false}
+    compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.62:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:ExtraCells2:2.5.35:dev') { transitive = false }
-    compileOnly('com.github.GTNewHorizons:ForestryMC:4.11.31:dev')
-    compileOnly('com.github.GTNewHorizons:EnderIO:2.10.33:dev')
-    compileOnly('com.github.GTNewHorizons:OpenComputers:1.12.50-GTNH:dev') { transitive = false }
+    compileOnly('com.github.GTNewHorizons:ForestryMC:4.11.32:dev')
+    compileOnly('com.github.GTNewHorizons:EnderIO:2.10.35:dev')
+    compileOnly('com.github.GTNewHorizons:OpenComputers:1.12.53-GTNH:dev') { transitive = false }
 
     compileOnly("org.jetbrains:annotations:26.1.0")
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -34,21 +34,21 @@
  * For more details, see https://docs.gradle.org/8.0.1/userguide/java_library_plugin.html#sec:java_library_configurations_graph
  */
 dependencies {
-    api('com.github.GTNewHorizons:NotEnoughItems:2.8.102-GTNH:dev')
-    api('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-983-GTNH:dev')
-    api('com.github.GTNewHorizons:waila:1.19.30:dev')
-    api("com.github.GTNewHorizons:GTNHLib:0.11.15:dev")
+    api('com.github.GTNewHorizons:NotEnoughItems:2.8.114-GTNH:dev')
+    api('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-999-GTNH:dev')
+    api('com.github.GTNewHorizons:waila:1.19.31:dev')
+    api("com.github.GTNewHorizons:GTNHLib:0.11.30:dev")
 
     compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.2.21-GTNH:dev')
-    compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.60:dev') {transitive = false}
+    compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.61:dev') {transitive = false}
     compileOnly('com.github.GTNewHorizons:ExtraCells2:2.5.35:dev') { transitive = false }
-    compileOnly('com.github.GTNewHorizons:ForestryMC:4.11.26:dev')
-    compileOnly('com.github.GTNewHorizons:EnderIO:2.10.31:dev')
-    compileOnly('com.github.GTNewHorizons:OpenComputers:1.12.45-GTNH:dev') { transitive = false }
+    compileOnly('com.github.GTNewHorizons:ForestryMC:4.11.31:dev')
+    compileOnly('com.github.GTNewHorizons:EnderIO:2.10.33:dev')
+    compileOnly('com.github.GTNewHorizons:OpenComputers:1.12.50-GTNH:dev') { transitive = false }
 
     compileOnly("org.jetbrains:annotations:26.1.0")
 
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:DuraDisplay:1.4.2:dev")
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:DuraDisplay:1.4.4:dev")
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:WirelessCraftingTerminal:1.12.16:dev") {
         exclude group: 'com.github.GTNewHorizons', module: 'Applied-Energistics-2-Unofficial'
     }

--- a/src/main/java/com/glodblock/github/common/parts/PartFluidInterface.java
+++ b/src/main/java/com/glodblock/github/common/parts/PartFluidInterface.java
@@ -27,9 +27,12 @@ import com.glodblock.github.loader.ItemAndBlockHolder;
 import com.glodblock.github.util.DualHostSettings;
 import com.glodblock.github.util.DualityFluidInterface;
 import com.glodblock.github.util.Util;
+import com.google.common.collect.ImmutableSet;
 
+import appeng.api.config.Actionable;
 import appeng.api.config.Upgrades;
 import appeng.api.networking.IGridNode;
+import appeng.api.networking.crafting.ICraftingLink;
 import appeng.api.networking.events.MENetworkChannelsChanged;
 import appeng.api.networking.events.MENetworkEventSubscribe;
 import appeng.api.networking.events.MENetworkPowerStatusChange;
@@ -37,6 +40,7 @@ import appeng.api.networking.ticking.TickRateModulation;
 import appeng.api.networking.ticking.TickingRequest;
 import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.data.IAEFluidStack;
+import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IAEStackType;
 import appeng.helpers.ICustomButtonDataObject;
 import appeng.helpers.ICustomButtonProvider;
@@ -149,6 +153,7 @@ public class PartFluidInterface extends PartInterface implements IDualHost, ICus
         config.readFromNBT(data, "ConfigInv");
         fluidDuality.loadConfigFromPacket(this.config);
         getInternalFluid().readFromNBT(data, "FluidInv");
+        fluidDuality.readCraftingTrackerFromNBT(data);
     }
 
     @Override
@@ -156,6 +161,7 @@ public class PartFluidInterface extends PartInterface implements IDualHost, ICus
         super.writeToNBT(data);
         config.writeToNBT(data, "ConfigInv");
         getInternalFluid().writeToNBT(data, "FluidInv");
+        fluidDuality.writeCraftingTrackerToNBT(data);
     }
 
     @Override
@@ -175,6 +181,26 @@ public class PartFluidInterface extends PartInterface implements IDualHost, ICus
     @Override
     public int getInstalledUpgrades(final Upgrades u) {
         return getInterfaceDuality().getInstalledUpgrades(u);
+    }
+
+    @Override
+    public ImmutableSet<ICraftingLink> getRequestedJobs() {
+        return ImmutableSet.<ICraftingLink>builder().addAll(super.getRequestedJobs())
+                .addAll(fluidDuality.getRequestedJobs()).build();
+    }
+
+    @Override
+    public IAEStack<?> injectCraftedItems(final ICraftingLink link, final IAEStack<?> items, final Actionable mode) {
+        if (items instanceof IAEFluidStack) {
+            return fluidDuality.injectCraftedItems(link, items, mode);
+        }
+        return super.injectCraftedItems(link, items, mode);
+    }
+
+    @Override
+    public void jobStateChange(final ICraftingLink link) {
+        super.jobStateChange(link);
+        fluidDuality.jobStateChange(link);
     }
 
     @Override

--- a/src/main/java/com/glodblock/github/common/parts/PartFluidP2PInterface.java
+++ b/src/main/java/com/glodblock/github/common/parts/PartFluidP2PInterface.java
@@ -28,13 +28,17 @@ import com.glodblock.github.loader.ItemAndBlockHolder;
 import com.glodblock.github.util.DualHostSettings;
 import com.glodblock.github.util.DualityFluidInterface;
 import com.glodblock.github.util.Util;
+import com.google.common.collect.ImmutableSet;
 
+import appeng.api.config.Actionable;
 import appeng.api.implementations.items.IMemoryCard;
 import appeng.api.networking.IGridNode;
+import appeng.api.networking.crafting.ICraftingLink;
 import appeng.api.networking.ticking.TickRateModulation;
 import appeng.api.networking.ticking.TickingRequest;
 import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.data.IAEFluidStack;
+import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IAEStackType;
 import appeng.api.util.IConfigManager;
 import appeng.helpers.DualityInterface;
@@ -138,6 +142,26 @@ public class PartFluidP2PInterface extends PartP2PInterface implements IDualHost
         } else {
             return fluid;
         }
+    }
+
+    @Override
+    public ImmutableSet<ICraftingLink> getRequestedJobs() {
+        return ImmutableSet.<ICraftingLink>builder().addAll(super.getRequestedJobs())
+                .addAll(dualityFluid.getRequestedJobs()).build();
+    }
+
+    @Override
+    public IAEStack<?> injectCraftedItems(final ICraftingLink link, final IAEStack<?> items, final Actionable mode) {
+        if (items instanceof IAEFluidStack) {
+            return dualityFluid.injectCraftedItems(link, items, mode);
+        }
+        return super.injectCraftedItems(link, items, mode);
+    }
+
+    @Override
+    public void jobStateChange(final ICraftingLink link) {
+        super.jobStateChange(link);
+        dualityFluid.jobStateChange(link);
     }
 
     @Override

--- a/src/main/java/com/glodblock/github/common/parts/PartFluidP2PInterface.java
+++ b/src/main/java/com/glodblock/github/common/parts/PartFluidP2PInterface.java
@@ -123,6 +123,23 @@ public class PartFluidP2PInterface extends PartP2PInterface implements IDualHost
     }
 
     @Override
+    public void readFromNBT(final NBTTagCompound data) {
+        super.readFromNBT(data);
+        config.readFromNBT(data, "ConfigInv");
+        dualityFluid.loadConfigFromPacket(this.config);
+        dualityFluid.getInternalFluid().readFromNBT(data, "FluidInv");
+        dualityFluid.readCraftingTrackerFromNBT(data);
+    }
+
+    @Override
+    public void writeToNBT(final NBTTagCompound data) {
+        super.writeToNBT(data);
+        config.writeToNBT(data, "ConfigInv");
+        dualityFluid.getInternalFluid().writeToNBT(data, "FluidInv");
+        dualityFluid.writeCraftingTrackerToNBT(data);
+    }
+
+    @Override
     public TickingRequest getTickingRequest(IGridNode node) {
         TickingRequest item = duality.getTickingRequest(node);
         TickingRequest fluid = dualityFluid.getTickingRequest(node);

--- a/src/main/java/com/glodblock/github/common/tile/TileFluidInterface.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileFluidInterface.java
@@ -28,11 +28,14 @@ import com.glodblock.github.loader.ItemAndBlockHolder;
 import com.glodblock.github.util.DualHostSettings;
 import com.glodblock.github.util.DualityFluidInterface;
 import com.glodblock.github.util.Util;
+import com.google.common.collect.ImmutableSet;
 
+import appeng.api.config.Actionable;
 import appeng.api.config.Settings;
 import appeng.api.config.SidelessMode;
 import appeng.api.config.Upgrades;
 import appeng.api.networking.IGridNode;
+import appeng.api.networking.crafting.ICraftingLink;
 import appeng.api.networking.events.MENetworkChannelsChanged;
 import appeng.api.networking.events.MENetworkEventSubscribe;
 import appeng.api.networking.events.MENetworkPowerStatusChange;
@@ -40,6 +43,7 @@ import appeng.api.networking.ticking.TickRateModulation;
 import appeng.api.networking.ticking.TickingRequest;
 import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.data.IAEFluidStack;
+import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IAEStackType;
 import appeng.api.util.IConfigManager;
 import appeng.helpers.ICustomButtonDataObject;
@@ -180,12 +184,14 @@ public class TileFluidInterface extends TileInterface implements IDualHost, ICus
         config.readFromNBT(data, "ConfigInv");
         fluidDuality.loadConfigFromPacket(this.config);
         getInternalFluid().readFromNBT(data, "FluidInv");
+        fluidDuality.readCraftingTrackerFromNBT(data);
     }
 
     @TileEvent(TileEventType.WORLD_NBT_WRITE)
     public NBTTagCompound writeToNBTEvent(NBTTagCompound data) {
         config.writeToNBT(data, "ConfigInv");
         getInternalFluid().writeToNBT(data, "FluidInv");
+        fluidDuality.writeCraftingTrackerToNBT(data);
         return data;
     }
 
@@ -214,6 +220,26 @@ public class TileFluidInterface extends TileInterface implements IDualHost, ICus
     @Override
     public int getInstalledUpgrades(final Upgrades u) {
         return getInterfaceDuality().getInstalledUpgrades(u);
+    }
+
+    @Override
+    public ImmutableSet<ICraftingLink> getRequestedJobs() {
+        return ImmutableSet.<ICraftingLink>builder().addAll(super.getRequestedJobs())
+                .addAll(fluidDuality.getRequestedJobs()).build();
+    }
+
+    @Override
+    public IAEStack<?> injectCraftedItems(final ICraftingLink link, final IAEStack<?> items, final Actionable mode) {
+        if (items instanceof IAEFluidStack) {
+            return fluidDuality.injectCraftedItems(link, items, mode);
+        }
+        return super.injectCraftedItems(link, items, mode);
+    }
+
+    @Override
+    public void jobStateChange(final ICraftingLink link) {
+        super.jobStateChange(link);
+        fluidDuality.jobStateChange(link);
     }
 
     @Override

--- a/src/main/java/com/glodblock/github/util/DualityFluidInterface.java
+++ b/src/main/java/com/glodblock/github/util/DualityFluidInterface.java
@@ -6,7 +6,6 @@ import static appeng.util.item.AEItemStackType.ITEM_STACK_TYPE;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
@@ -26,12 +25,14 @@ import com.glodblock.github.common.item.ItemFluidPacket;
 import com.glodblock.github.inventory.AEFluidInventory;
 import com.glodblock.github.inventory.IAEFluidInventory;
 import com.glodblock.github.inventory.IAEFluidTank;
+import com.google.common.collect.ImmutableSet;
 
 import appeng.api.config.Actionable;
 import appeng.api.config.Upgrades;
 import appeng.api.implementations.IUpgradeableHost;
 import appeng.api.networking.GridFlags;
 import appeng.api.networking.IGridNode;
+import appeng.api.networking.crafting.ICraftingLink;
 import appeng.api.networking.events.MENetworkChannelsChanged;
 import appeng.api.networking.events.MENetworkPowerStatusChange;
 import appeng.api.networking.security.BaseActionSource;
@@ -46,10 +47,12 @@ import appeng.api.storage.IStorageMonitorable;
 import appeng.api.storage.data.AEStackTypeRegistry;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEItemStack;
+import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IAEStackType;
 import appeng.api.util.IConfigManager;
 import appeng.core.settings.TickRates;
 import appeng.helpers.IInterfaceHost;
+import appeng.helpers.MultiCraftingTracker;
 import appeng.me.GridAccessException;
 import appeng.me.helpers.AENetworkProxy;
 import appeng.me.storage.MEMonitorIFluidHandler;
@@ -75,6 +78,7 @@ public class DualityFluidInterface implements IGridTickable, IStorageMonitorable
     private final IAEFluidStack[] requireWork;
     private int isWorking = -1;
     private final Map<IAEStackType<?>, MEMonitorPassThrough<?>> monitorMap;
+    private final MultiCraftingTracker craftingTracker;
 
     public DualityFluidInterface(final AENetworkProxy networkProxy, final IInterfaceHost ih) {
         this.gridProxy = networkProxy;
@@ -94,6 +98,8 @@ public class DualityFluidInterface implements IGridTickable, IStorageMonitorable
         for (int i = 0; i < 6; ++i) {
             this.requireWork[i] = null;
         }
+
+        this.craftingTracker = new MultiCraftingTracker(this.iHost, NUMBER_OF_TANKS);
     }
 
     public IAEFluidStack getStandardFluid(IAEFluidStack fluid) {
@@ -147,6 +153,18 @@ public class DualityFluidInterface implements IGridTickable, IStorageMonitorable
         this.readConfig();
     }
 
+    public void writeCraftingTrackerToNBT(NBTTagCompound data) {
+        final NBTTagCompound tracker = new NBTTagCompound();
+        this.craftingTracker.writeToNBT(tracker);
+        data.setTag("fluidCraftingLinks", tracker);
+    }
+
+    public void readCraftingTrackerFromNBT(NBTTagCompound data) {
+        if (data.hasKey("fluidCraftingLinks")) {
+            this.craftingTracker.readFromNBT(data.getCompoundTag("fluidCraftingLinks"));
+        }
+    }
+
     public void writeConfigToNBT(NBTTagCompound data, String name) {
         this.config.writeToNBT(data, name);
     }
@@ -182,7 +200,7 @@ public class DualityFluidInterface implements IGridTickable, IStorageMonitorable
 
     @Override
     public int getInstalledUpgrades(Upgrades u) {
-        return 0;
+        return this.iHost.getInstalledUpgrades(u);
     }
 
     @Override
@@ -326,9 +344,11 @@ public class DualityFluidInterface implements IGridTickable, IStorageMonitorable
         }
         IAEFluidStack toStore;
         if (work.getStackSize() > 0L) {
-            if ((long) this.tanks.fill(slot, work.getFluidStack(), false) != work.getStackSize()) {
+            if (this.craftingTracker.isBusy(slot)) {
+                changed = this.handleCrafting(slot, work);
+            } else if ((long) this.tanks.fill(slot, work.getFluidStack(), false) != work.getStackSize()) {
                 changed = true;
-            } else if (Objects.requireNonNull(getFluidGrid()).getStorageList().findPrecise(work) != null) {
+            } else {
                 toStore = dest.extractItems(work, Actionable.MODULATE, this.mySource);
                 if (toStore != null) {
                     changed = true;
@@ -336,6 +356,8 @@ public class DualityFluidInterface implements IGridTickable, IStorageMonitorable
                     if ((long) filled != toStore.getStackSize()) {
                         throw new IllegalStateException("bad attempt at managing tanks. ( fill )");
                     }
+                } else {
+                    changed = this.handleCrafting(slot, work);
                 }
             }
         } else if (work.getStackSize() < 0L) {
@@ -363,6 +385,57 @@ public class DualityFluidInterface implements IGridTickable, IStorageMonitorable
 
         this.isWorking = -1;
         return changed;
+    }
+
+    private boolean handleCrafting(final int slot, final IAEFluidStack fluidStack) {
+        try {
+            if (this.getInstalledUpgrades(Upgrades.CRAFTING) > 0 && fluidStack != null) {
+                return this.craftingTracker.handleCrafting(
+                        slot,
+                        fluidStack.getStackSize(),
+                        (IAEStack<?>) fluidStack,
+                        this.iHost.getTileEntity().getWorldObj(),
+                        this.gridProxy.getGrid(),
+                        this.gridProxy.getCrafting(),
+                        this.mySource);
+            }
+        } catch (final GridAccessException e) {
+            // :P
+        }
+        return false;
+    }
+
+    public ImmutableSet<ICraftingLink> getRequestedJobs() {
+        return this.craftingTracker.getRequestedJobs();
+    }
+
+    public IAEStack<?> injectCraftedItems(final ICraftingLink link, final IAEStack<?> acquired, final Actionable mode) {
+        final int slot = this.craftingTracker.getSlot(link);
+
+        if (acquired instanceof IAEFluidStack afs && slot >= 0 && slot < NUMBER_OF_TANKS) {
+            if (mode == Actionable.SIMULATE) {
+                final int filled = this.tanks.fill(slot, afs.getFluidStack(), false);
+                return filled >= afs.getFluidStack().amount ? null
+                        : AEFluidStack.create(drainRemainder(afs.getFluidStack(), filled));
+            } else {
+                final int filled = this.tanks.fill(slot, afs.getFluidStack(), true);
+                this.updatePlan(slot);
+                return filled >= afs.getFluidStack().amount ? null
+                        : AEFluidStack.create(drainRemainder(afs.getFluidStack(), filled));
+            }
+        }
+
+        return acquired;
+    }
+
+    private static FluidStack drainRemainder(final FluidStack original, final int accepted) {
+        final FluidStack remainder = original.copy();
+        remainder.amount -= accepted;
+        return remainder;
+    }
+
+    public void jobStateChange(final ICraftingLink link) {
+        this.craftingTracker.jobStateChange(link);
     }
 
     private void updatePlan(int slot) {


### PR DESCRIPTION
The fluid side of the ME Interface never read Crafting Card upgrades and never fell back to crafting when a fluid could not be extracted from the network, so a fluid configured with a Crafting Card installed never actually got crafted, only ever pulled from existing network stock.

Depends on GTNewHorizons/Applied-Energistics-2-Unofficial#1441, which widens MultiCraftingTracker's visibility so it can be reused here and fixes it getting stuck when a crafting job can't be planned. This PR will not build until that one is merged and the AE2 dependency version is bumped.