### PR TITLE
allow to clear fluid storage bus settings

### DIFF
--- a/src/main/java/com/glodblock/github/loader/RecipeLoader.java
+++ b/src/main/java/com/glodblock/github/loader/RecipeLoader.java
@@ -269,6 +269,7 @@ public class RecipeLoader implements Runnable {
                         'W',
                         AE2_WORK_BENCH));
         GameRegistry.addShapelessRecipe(FLUID_STORAGE_BUS.stack(), FLUID_INTERFACE, STICKY_PISTON, PISTON);
+        GameRegistry.addShapelessRecipe(FLUID_STORAGE_BUS.stack(), FLUID_STORAGE_BUS);
         GameRegistry.addShapelessRecipe(FLUID_STORAGE_BUS.stack(), INTERFACE, STICKY_PISTON, PISTON);
         GameRegistry.addRecipe(
                 new ShapedOreRecipe(


### PR DESCRIPTION
## Summary
regular storagebus can be cleared, so lets mirror it for the fluid one too!

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
