### PR TITLE
Cache enum `.values()`

### DIFF
--- a/src/main/java/com/glodblock/github/client/UltraTerminalButtons.java
+++ b/src/main/java/com/glodblock/github/client/UltraTerminalButtons.java
@@ -215,7 +215,7 @@ public class UltraTerminalButtons implements ICustomButtonDataObject {
     public void readData(NBTTagCompound tag) {
         this.reStock = tag.getBoolean(restockItems);
         this.magnetMode = WirelessMagnet.Mode.values()[tag.getInteger(modeKey)];
-        this.terminalMode = UltraTerminalModes.values()[tag.getInteger(MODE)];
+        this.terminalMode = UltraTerminalModes.VALUES[tag.getInteger(MODE)];
     }
 
     @Override
@@ -229,7 +229,7 @@ public class UltraTerminalButtons implements ICustomButtonDataObject {
     public void readByte(ByteBuf buf) {
         this.reStock = buf.readBoolean();
         this.magnetMode = WirelessMagnet.Mode.values()[buf.readInt()];
-        this.terminalMode = UltraTerminalModes.values()[buf.readInt()];
+        this.terminalMode = UltraTerminalModes.VALUES[buf.readInt()];
         ItemWirelessUltraTerminal.setMode(this.terminal, this.terminalMode);
 
         toggleMagnetButtonsVisibility();

--- a/src/main/java/com/glodblock/github/common/item/ItemBaseWirelessTerminal.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemBaseWirelessTerminal.java
@@ -103,7 +103,7 @@ public class ItemBaseWirelessTerminal extends ToolWirelessTerminal implements II
         Item item = is.getItem();
         if (item instanceof ItemWirelessUltraTerminal) {
             if (!is.hasTagCompound()) is.setTagCompound(new NBTTagCompound());
-            return UltraTerminalModes.values()[is.getTagCompound().getInteger(MODE)];
+            return UltraTerminalModes.VALUES[is.getTagCompound().getInteger(MODE)];
         } else if (item instanceof ItemWirelessPatternTerminal) {
             return UltraTerminalModes.PATTERN;
         } else if (item instanceof ItemWirelessInterfaceTerminal) {

--- a/src/main/java/com/glodblock/github/common/item/ItemWirelessUltraTerminal.java
+++ b/src/main/java/com/glodblock/github/common/item/ItemWirelessUltraTerminal.java
@@ -194,7 +194,7 @@ public class ItemWirelessUltraTerminal extends ItemBaseWirelessTerminal
     public IGuiItemObject getGuiObject(ItemStack is, World world, EntityPlayer p, int x, int y, int z) {
         final IWirelessTermHandler wh = AEApi.instance().registries().wireless().getWirelessTerminalHandler(is);
         if (wh == null) return null;
-        return switch (y != Integer.MIN_VALUE ? UltraTerminalModes.values()[y] : getMode(is)) {
+        return switch (y != Integer.MIN_VALUE ? UltraTerminalModes.VALUES[y] : getMode(is)) {
             case CRAFTING -> new WirelessCraftingTerminalGuiObject(wh, is, p, world, x, y, z);
             case PATTERN, PATTERN_EX -> new WirelessPatternTerminalGuiObject(wh, is, p, world, x, y, z);
             case INTERFACE -> new WirelessInterfaceTerminalGuiObject(wh, is, x);

--- a/src/main/java/com/glodblock/github/inventory/item/WirelessMagnet.java
+++ b/src/main/java/com/glodblock/github/inventory/item/WirelessMagnet.java
@@ -29,7 +29,9 @@ public class WirelessMagnet {
 
         Off,
         Inv,
-        ME
+        ME;
+
+        public static final Mode[] VALUES = values();
     }
 
     public enum ListMode {
@@ -138,7 +140,7 @@ public class WirelessMagnet {
         if (is != null && is.getItem() instanceof ItemWirelessUltraTerminal) {
             NBTTagCompound data = Platform.openNbtData(is);
             if (data.hasKey(modeKey)) {
-                return Mode.values()[data.getInteger(modeKey)];
+                return Mode.VALUES[data.getInteger(modeKey)];
             }
             setMode(is, Mode.Off);
         }

--- a/src/main/java/com/glodblock/github/network/CPacketSwitchGuis.java
+++ b/src/main/java/com/glodblock/github/network/CPacketSwitchGuis.java
@@ -54,7 +54,7 @@ public class CPacketSwitchGuis implements IMessage {
     @Override
     public void fromBytes(ByteBuf byteBuf) {
         final int ord = byteBuf.readInt();
-        mode = ord != -1 ? UltraTerminalModes.values()[ord] : null;
+        mode = ord != -1 ? UltraTerminalModes.VALUES[ord] : null;
         switchTerminal = byteBuf.readBoolean();
     }
 

--- a/src/main/java/com/glodblock/github/util/UltraTerminalModes.java
+++ b/src/main/java/com/glodblock/github/util/UltraTerminalModes.java
@@ -1,6 +1,7 @@
 package com.glodblock.github.util;
 
 public enum UltraTerminalModes {
+
     CRAFTING,
     PATTERN,
     PATTERN_EX,

--- a/src/main/java/com/glodblock/github/util/UltraTerminalModes.java
+++ b/src/main/java/com/glodblock/github/util/UltraTerminalModes.java
@@ -5,5 +5,7 @@ public enum UltraTerminalModes {
     PATTERN,
     PATTERN_EX,
     INTERFACE,
-    LEVEL
+    LEVEL;
+
+    public static final UltraTerminalModes[] VALUES = values();
 }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
caching enum values() calls that got called more than 500 times during my little playtest.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
