### PR TITLE
Cache enum `.values()`

### DIFF
--- a/src/main/java/com/glodblock/github/common/storage/CellType.java
+++ b/src/main/java/com/glodblock/github/common/storage/CellType.java
@@ -19,6 +19,8 @@ public enum CellType {
     Cell4096kPart(6, AEFeature.StorageCells),
     Cell16384kPart(7, AEFeature.StorageCells);
 
+    public static final CellType[] VALUES = values();
+
     private final EnumSet<AEFeature> features;
     private int damageValue;
     private Item itemInstance;
@@ -53,7 +55,7 @@ public enum CellType {
     }
 
     public static EnumChatFormatting getTypeColor(int type) {
-        return getTypeColor(CellType.values()[type % CellType.values().length]);
+        return getTypeColor(CellType.VALUES[type % CellType.VALUES.length]);
     }
 
     public static EnumChatFormatting getTypeColor(CellType type) {


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
caching enum values() calls that got called more than 500 times during my little playtest.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
