### PR TITLE
Fix fluid packet orientation when rendered as an entity

### DIFF
--- a/src/main/java/com/glodblock/github/client/render/ItemPacketRender.java
+++ b/src/main/java/com/glodblock/github/client/render/ItemPacketRender.java
@@ -42,6 +42,12 @@ public class ItemPacketRender implements IItemRenderer {
         GL11.glEnable(GL11.GL_BLEND);
         GL11.glEnable(GL11.GL_ALPHA_TEST);
         GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+        final boolean entity = type.equals(ItemRenderType.ENTITY);
+        if (entity) {
+            GL11.glPushMatrix();
+            GL11.glRotated(90.0D, 0.0D, 1.0D, 0.0D);
+            GL11.glTranslated(-0.5D, -0.6D, 0.0D);
+        }
 
         FluidStack fluid = ItemFluidPacket.getFluidStack(item);
         int RGB = fluid == null ? 0xFFFFFF : fluid.getFluid().getColor(fluid);
@@ -65,6 +71,9 @@ public class ItemPacketRender implements IItemRenderer {
                     0.0625F);
         }
 
+        if (entity) {
+            GL11.glPopMatrix();
+        }
         GL11.glDisable(GL11.GL_BLEND);
         GL11.glDisable(GL11.GL_ALPHA_TEST);
     }


### PR DESCRIPTION
## Summary
Fluid packets are rendered as a flat quad without the orientation fix that ItemDropRender applies for the ENTITY render type, so they end up edge-on to the player. This shows up wherever they are drawn as a static item entity, for example in an item frame or in a HoloInventory hologram.

The transform is wrapped in a push/pop pair, otherwise it leaks into the current modelview and offsets the block selection box.


## Checklist
- [ ] I have tested this PR in DevEnv
- [X] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
