### PR TITLE
Fix universal terminal selection

### DIFF
--- a/src/main/java/com/glodblock/github/network/CPacketSwitchGuis.java
+++ b/src/main/java/com/glodblock/github/network/CPacketSwitchGuis.java
@@ -28,6 +28,7 @@ import appeng.container.ContainerOpenContext;
 import appeng.container.PrimaryGui;
 import appeng.container.interfaces.IContainerSubGui;
 import appeng.helpers.ICustomButtonProvider;
+import appeng.util.Platform;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;
@@ -75,7 +76,7 @@ public class CPacketSwitchGuis implements IMessage {
             // switch terminal
 
             if (message.switchTerminal) {
-                ImmutablePair<Integer, ItemStack> temp = Util.getUltraWirelessTerm(player);
+                ImmutablePair<Integer, ItemStack> temp = getTerminalToSwitch(player, cont);
                 if (temp != null && temp.getRight().getItem() instanceof ItemWirelessUltraTerminal iwut) {
                     if (message.mode != null && cont instanceof AEBaseContainer abc) {
                         abc.setSwitchAbleGuiNext(message.mode.ordinal());
@@ -117,6 +118,21 @@ public class CPacketSwitchGuis implements IMessage {
                 }
             }
             return null;
+        }
+
+        private static ImmutablePair<Integer, ItemStack> getTerminalToSwitch(EntityPlayerMP player, Container cont) {
+            if (cont instanceof AEBaseContainer aeBaseContainer) {
+                final int slot = aeBaseContainer.getTargetSlotIndex();
+                if (slot == Integer.MIN_VALUE) return null;
+
+                final ItemStack terminal = Platform.getItemFromPlayerInventoryBySlotIndex(player, slot);
+                return terminal != null && terminal.getItem() instanceof ItemWirelessUltraTerminal
+                        ? new ImmutablePair<>(slot, terminal)
+                        : null;
+            }
+
+            // Global terminal hotkeys have no open item GUI from which to obtain an exact slot.
+            return Util.getUltraWirelessTerm(player);
         }
     }
 

--- a/src/main/java/com/glodblock/github/util/Util.java
+++ b/src/main/java/com/glodblock/github/util/Util.java
@@ -160,11 +160,12 @@ public final class Util {
     }
 
     public static ImmutablePair<Integer, ItemStack> getUltraWirelessTerm(EntityPlayer player) {
-        int invSize = player.inventory.getSizeInventory();
+        final ImmutablePair<Integer, ItemStack> baublesTerminal = getBaublesUltraWirelessTerm(player);
+        return baublesTerminal != null ? baublesTerminal : getInventoryUltraWirelessTerm(player);
+    }
 
-        if (invSize <= 0) {
-            return null;
-        }
+    private static ImmutablePair<Integer, ItemStack> getInventoryUltraWirelessTerm(EntityPlayer player) {
+        final int invSize = player.inventory.getSizeInventory();
         for (int i = 0; i < invSize; ++i) {
             ItemStack is = player.inventory.getStackInSlot(i);
             if (is != null && is.getItem() instanceof ItemWirelessUltraTerminal) {
@@ -172,10 +173,14 @@ public final class Util {
             }
         }
 
+        return null;
+    }
+
+    private static ImmutablePair<Integer, ItemStack> getBaublesUltraWirelessTerm(EntityPlayer player) {
         if (ModAndClassUtil.BAUBLES) {
-            IInventory handler = BaublesApi.getBaubles(player);
+            final IInventory handler = BaublesApi.getBaubles(player);
             if (handler != null) {
-                invSize = handler.getSizeInventory();
+                final int invSize = handler.getSizeInventory();
                 for (int i = 0; i < invSize; ++i) {
                     ItemStack is = handler.getStackInSlot(i);
                     if (is != null && is.getItem() instanceof ItemWirelessUltraTerminal) {


### PR DESCRIPTION
## Summary
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19436 by preserving the exact Universal Wireless Terminal used when switching tabs, preventing players with multiple terminals from being moved to the wrong ME network. Global terminal actions now prefer the terminal equipped in a Baubles slot, falling back to an inventory terminal when none is equipped.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
