### PR TITLE
Fix fluid transfer through inactive interfaces

### DIFF
--- a/src/main/java/com/glodblock/github/util/DualityFluidInterface.java
+++ b/src/main/java/com/glodblock/github/util/DualityFluidInterface.java
@@ -191,6 +191,8 @@ public class DualityFluidInterface implements IGridTickable, IStorageMonitorable
     }
 
     private IMEMonitor<IAEFluidStack> getFluidGrid() {
+        if (!this.gridProxy.isActive()) return null;
+
         try {
             return gridProxy.getGrid().<IStorageGrid>getCache(IStorageGrid.class).getFluidInventory();
         } catch (GridAccessException e) {


### PR DESCRIPTION
## Summary
Added an active-channel check to `DualityFluidInterface` before accessing the ME fluid inventory. Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21121

Fluid interfaces without an assigned channel can no longer push fluids into network storage, while normally connected interfaces continue to work as before.


## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
