### PR TITLE
make level maintainer able to use lite crafting mode

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -35,7 +35,7 @@
  */
 dependencies {
     api('com.github.GTNewHorizons:NotEnoughItems:2.8.121-GTNH:dev')
-    api('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-1030-GTNH:dev')
+    api('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-1040-GTNH:dev')
     api('com.github.GTNewHorizons:waila:1.19.31:dev')
     api("com.github.GTNewHorizons:GTNHLib:0.11.37:dev")
 

--- a/src/main/java/com/glodblock/github/client/gui/GuiLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiLevelMaintainer.java
@@ -99,7 +99,7 @@ public class GuiLevelMaintainer extends GuiSub {
                         194,
                         GuiText.CraftingModeLite.getLocal(),
                         GuiText.CraftingModeLiteDesc.getLocal()));
-        this.liteMode.setState(this.cont.getTile().isLiteMode());
+        this.liteMode.setState(false);
     }
 
     @Override
@@ -222,10 +222,8 @@ public class GuiLevelMaintainer extends GuiSub {
             }
         }
         if (btn == this.liteMode) {
-            boolean newState = !this.cont.getTile().isLiteMode();
-            this.liteMode.setState(newState);
             FluidCraft.proxy.netHandler
-                    .sendToServer(new CPacketLevelMaintainer(CPacketLevelMaintainer.Action.LiteMode, newState));
+                    .sendToServer(new CPacketLevelMaintainer(CPacketLevelMaintainer.Action.LiteMode));
             return;
         }
         super.actionPerformed(btn);

--- a/src/main/java/com/glodblock/github/client/gui/GuiLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiLevelMaintainer.java
@@ -29,6 +29,8 @@ import appeng.api.storage.data.IAEStackType;
 import appeng.client.gui.GuiSub;
 import appeng.client.gui.slots.VirtualMEPhantomSlot;
 import appeng.client.gui.widgets.GuiTabButton;
+import appeng.client.gui.widgets.GuiToggleButton;
+import appeng.core.localization.GuiText;
 import appeng.util.calculators.ArithHelper;
 import appeng.util.calculators.Calculator;
 
@@ -40,6 +42,7 @@ public class GuiLevelMaintainer extends GuiSub {
     private final MouseRegionManager mouseRegions = new MouseRegionManager(this);
     private Widget focusedWidget;
     private final FontRenderer render;
+    private GuiToggleButton liteMode;
 
     public GuiLevelMaintainer(InventoryPlayer ipl, TileLevelMaintainer tile) {
         super(new ContainerLevelMaintainer(ipl, tile));
@@ -88,6 +91,15 @@ public class GuiLevelMaintainer extends GuiSub {
                     this.buttonList,
                     this.cont);
         }
+        this.buttonList.add(
+                this.liteMode = new GuiToggleButton(
+                        guiLeft - 18,
+                        guiTop + 60,
+                        178,
+                        194,
+                        GuiText.CraftingModeLite.getLocal(),
+                        GuiText.CraftingModeLiteDesc.getLocal()));
+        this.liteMode.setState(this.cont.getTile().isLiteMode());
     }
 
     @Override
@@ -208,6 +220,13 @@ public class GuiLevelMaintainer extends GuiSub {
             if (com.sendToServer(btn)) {
                 return;
             }
+        }
+        if (btn == this.liteMode) {
+            boolean newState = !this.cont.getTile().isLiteMode();
+            this.liteMode.setState(newState);
+            FluidCraft.proxy.netHandler
+                    .sendToServer(new CPacketLevelMaintainer(CPacketLevelMaintainer.Action.LiteMode, newState));
+            return;
         }
         super.actionPerformed(btn);
     }

--- a/src/main/java/com/glodblock/github/client/gui/GuiLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiLevelMaintainer.java
@@ -94,7 +94,7 @@ public class GuiLevelMaintainer extends GuiSub {
         this.buttonList.add(
                 this.liteMode = new GuiToggleButton(
                         guiLeft - 18,
-                        guiTop + 60,
+                        guiTop + 2,
                         178,
                         194,
                         GuiText.CraftingModeLite.getLocal(),

--- a/src/main/java/com/glodblock/github/client/gui/GuiLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiLevelMaintainer.java
@@ -98,7 +98,7 @@ public class GuiLevelMaintainer extends GuiSub {
                         178,
                         194,
                         GuiText.CraftingModeLite.getLocal(),
-                        GuiText.CraftingModeLiteDesc.getLocal()));
+                        NameConst.TT_LEVEL_MAINTAINER_LITE_CRAFT_DESC));
         this.liteMode.setState(false);
     }
 
@@ -222,8 +222,11 @@ public class GuiLevelMaintainer extends GuiSub {
             }
         }
         if (btn == this.liteMode) {
-            FluidCraft.proxy.netHandler
-                    .sendToServer(new CPacketLevelMaintainer(CPacketLevelMaintainer.Action.LiteMode));
+            if (isShiftKeyDown()) {
+                FluidCraft.proxy.netHandler.sendToServer(new CPacketLevelMaintainer(Action.ClearLiteMode));
+            } else {
+                FluidCraft.proxy.netHandler.sendToServer(new CPacketLevelMaintainer(Action.ToggleLiteMode));
+            }
             return;
         }
         super.actionPerformed(btn);

--- a/src/main/java/com/glodblock/github/client/gui/GuiLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiLevelMaintainer.java
@@ -246,6 +246,10 @@ public class GuiLevelMaintainer extends GuiSub {
         component[index].setState(state);
     }
 
+    public void updateComponent(boolean isLiteMode) {
+        this.liteMode.setState(isLiteMode);
+    }
+
     private static boolean acceptType(VirtualMEPhantomSlot slot, IAEStackType<?> type, int mouseButton) {
         return true;
     }

--- a/src/main/java/com/glodblock/github/client/gui/container/ContainerLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/client/gui/container/ContainerLevelMaintainer.java
@@ -110,7 +110,7 @@ public class ContainerLevelMaintainer extends ContainerSubGui implements IVirtua
                     (EntityPlayerMP) this.getInventoryPlayer().player);
         }
         FluidCraft.proxy.netHandler.sendTo(
-                new SPacketLevelMaintainerGuiUpdate(this.tile.requests, !this.isFirstUpdate),
+                new SPacketLevelMaintainerGuiUpdate(this.tile.requests, !this.isFirstUpdate, this.tile.isLiteMode()),
                 (EntityPlayerMP) this.getInventoryPlayer().player);
         this.isFirstUpdate = false;
         this.updateCount = 0;
@@ -126,7 +126,7 @@ public class ContainerLevelMaintainer extends ContainerSubGui implements IVirtua
                 NetworkHandler.instance
                         .sendTo(new PacketVirtualSlot(StorageName.NONE, slotStacks), (EntityPlayerMP) player);
                 FluidCraft.proxy.netHandler.sendTo(
-                        new SPacketLevelMaintainerGuiUpdate(this.tile.requests, false),
+                        new SPacketLevelMaintainerGuiUpdate(this.tile.requests, false, this.tile.isLiteMode()),
                         (EntityPlayerMP) player);
             }
         }

--- a/src/main/java/com/glodblock/github/common/tile/TileLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileLevelMaintainer.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableSet;
 
 import appeng.api.AEApi;
 import appeng.api.config.Actionable;
+import appeng.api.config.CraftingMode;
 import appeng.api.config.PowerMultiplier;
 import appeng.api.features.ILevelViewable;
 import appeng.api.features.LevelItemInfo;
@@ -50,6 +51,7 @@ import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IAEStack;
 import appeng.core.AELog;
 import appeng.me.GridAccessException;
+import appeng.me.cache.CraftingGridCache;
 import appeng.tile.TileEvent;
 import appeng.tile.events.TileEventType;
 import appeng.tile.grid.AENetworkTile;
@@ -78,6 +80,7 @@ public class TileLevelMaintainer extends AENetworkTile
     private int firstRequest = 0;
     private final BaseActionSource source;
     private boolean isPowered = false;
+    private boolean isLiteMode = false;
 
     public TileLevelMaintainer() {
         getProxy().setIdlePowerUsage(1D);
@@ -164,6 +167,7 @@ public class TileLevelMaintainer extends AENetworkTile
         }
         try {
             final ICraftingGrid craftingGrid = getProxy().getCrafting();
+            final CraftingGridCache craftingGridCache = (CraftingGridCache) craftingGrid;
             final IGrid grid = getProxy().getGrid();
 
             // Check there are available crafting CPUs before doing any work.
@@ -273,9 +277,14 @@ public class TileLevelMaintainer extends AENetworkTile
                 }
             } else if (itemToBegin != null) {
                 // No jobs to submit, start calculating some item.
-
-                requests[itemToBeginIdx].job = craftingGrid
-                        .beginCraftingJob(this.worldObj, grid, source, itemToBegin, null);
+                requests[itemToBeginIdx].job = craftingGridCache.beginCraftingJob(
+                        this.worldObj,
+                        grid,
+                        source,
+                        itemToBegin,
+                        CraftingMode.STANDARD,
+                        isLiteMode,
+                        null);
                 this.updateState(itemToBeginIdx, LevelState.Craft);
 
                 // Try the next item next time.
@@ -367,6 +376,16 @@ public class TileLevelMaintainer extends AENetworkTile
             requests[idx] = new RequestInfo(stack, this);
         }
         this.saveChanges();
+    }
+
+    public boolean isLiteMode() {
+        return this.isLiteMode;
+    }
+
+    public void setLiteMode(boolean liteMode) {
+        this.isLiteMode = liteMode;
+        this.saveChanges();
+        this.markForUpdate();
     }
 
     private void updateLink(int idx, @Nullable ICraftingLink link) {

--- a/src/main/java/com/glodblock/github/common/tile/TileLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileLevelMaintainer.java
@@ -589,6 +589,12 @@ public class TileLevelMaintainer extends AENetworkTile
                 }
             }
         }
+        if (compound.hasKey(NBT_LITE_MODE)) {
+            this.isLiteModeOverridden = true;
+            this.isLiteMode = compound.getBoolean(NBT_LITE_MODE);
+        } else {
+            this.isLiteModeOverridden = false;
+        }
         this.saveChanges();
     }
 
@@ -605,6 +611,9 @@ public class TileLevelMaintainer extends AENetworkTile
             }
         }
         compound.setTag(NBT_REQUESTS, tagList);
+        if (isLiteModeOverridden) {
+            compound.setBoolean(NBT_LITE_MODE, isLiteMode);
+        }
         return compound;
     }
 

--- a/src/main/java/com/glodblock/github/common/tile/TileLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileLevelMaintainer.java
@@ -75,6 +75,7 @@ public class TileLevelMaintainer extends AENetworkTile
     public static final String NBT_ENABLE = "enable";
     public static final String NBT_STATE = "state";
     public static final String NBT_LINK = "link";
+    public static final String NBT_LITE_MODE = "lite_mode";
 
     public final RequestInfo[] requests = new RequestInfo[REQ_COUNT];
     private final LevelMaintainerInventory inventory = new LevelMaintainerInventory(requests);
@@ -386,7 +387,6 @@ public class TileLevelMaintainer extends AENetworkTile
     public void setLiteMode(boolean liteMode) {
         this.isLiteMode = liteMode;
         this.saveChanges();
-        this.markForUpdate();
     }
 
     private void updateLink(int idx, @Nullable ICraftingLink link) {
@@ -436,6 +436,7 @@ public class TileLevelMaintainer extends AENetworkTile
             }
         }
         data.setTag(NBT_REQUESTS, tagList);
+        data.setBoolean(NBT_LITE_MODE, isLiteMode());
     }
 
     @TileEvent(TileEventType.WORLD_NBT_READ)
@@ -519,6 +520,9 @@ public class TileLevelMaintainer extends AENetworkTile
                 this.requests[i].quantity = quantyties[i];
             }
         }
+        if (data.hasKey(NBT_LITE_MODE)) {
+            this.isLiteMode = data.getBoolean(NBT_LITE_MODE);
+        }
     }
 
     // Remove old format NBT data from ItemStack
@@ -536,14 +540,12 @@ public class TileLevelMaintainer extends AENetworkTile
     public boolean readFromStream(final ByteBuf data) {
         final boolean oldPower = isPowered;
         isPowered = data.readBoolean();
-        isLiteMode = data.readBoolean();
         return isPowered != oldPower;
     }
 
     @TileEvent(TileEventType.NETWORK_WRITE)
     public void writeToStream(final ByteBuf data) {
         data.writeBoolean(isActive());
-        data.writeBoolean(isLiteMode);
     }
 
     @Override

--- a/src/main/java/com/glodblock/github/common/tile/TileLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileLevelMaintainer.java
@@ -536,12 +536,14 @@ public class TileLevelMaintainer extends AENetworkTile
     public boolean readFromStream(final ByteBuf data) {
         final boolean oldPower = isPowered;
         isPowered = data.readBoolean();
+        isLiteMode = data.readBoolean();
         return isPowered != oldPower;
     }
 
     @TileEvent(TileEventType.NETWORK_WRITE)
     public void writeToStream(final ByteBuf data) {
         data.writeBoolean(isActive());
+        data.writeBoolean(isLiteMode);
     }
 
     @Override

--- a/src/main/java/com/glodblock/github/common/tile/TileLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileLevelMaintainer.java
@@ -58,6 +58,7 @@ import appeng.tile.grid.AENetworkTile;
 import appeng.tile.inventory.IAEAppEngInventory;
 import appeng.tile.inventory.IAEStackInventory;
 import appeng.tile.inventory.InvOperation;
+import appeng.util.IterationCounter;
 import appeng.util.Platform;
 import appeng.util.SettingsFrom;
 import appeng.util.item.AEItemStack;
@@ -206,7 +207,7 @@ public class TileLevelMaintainer extends AENetworkTile
                 IMEMonitor monitor = getProxy().getStorage().getMEMonitor(craftItem.getStackType());
                 if (monitor == null) continue;
 
-                IAEStack<?> stackInStorage = monitor.getStorageList().findPrecise(craftItem);
+                IAEStack<?> stackInStorage = monitor.getAvailableItem(craftItem, IterationCounter.fetchNewId());
 
                 long stackSize = stackInStorage == null ? 0 : stackInStorage.getStackSize();
 

--- a/src/main/java/com/glodblock/github/common/tile/TileLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileLevelMaintainer.java
@@ -82,6 +82,7 @@ public class TileLevelMaintainer extends AENetworkTile
     private int firstRequest = 0;
     private final BaseActionSource source;
     private boolean isPowered = false;
+    private boolean isLiteModeOverridden = false;
     private boolean isLiteMode = false;
 
     public TileLevelMaintainer() {
@@ -285,7 +286,7 @@ public class TileLevelMaintainer extends AENetworkTile
                         source,
                         itemToBegin,
                         CraftingMode.STANDARD,
-                        isLiteMode,
+                        isLiteMode(),
                         null);
                 this.updateState(itemToBeginIdx, LevelState.Craft);
 
@@ -380,17 +381,33 @@ public class TileLevelMaintainer extends AENetworkTile
         this.saveChanges();
     }
 
+    private boolean getLiteModeDefault() {
+        try {
+            final ICraftingGrid craftingGrid = getProxy().getCrafting();
+            if (craftingGrid instanceof CraftingGridCache cache) {
+                return cache.getLiteCraftingDefault();
+            }
+        } catch (GridAccessException ignored) {}
+        return false;
+    }
+
     public boolean isLiteMode() {
-        return this.isLiteMode;
+        return this.isLiteModeOverridden ? this.isLiteMode : getLiteModeDefault();
     }
 
     public void setLiteMode(boolean liteMode) {
+        this.isLiteModeOverridden = true;
         this.isLiteMode = liteMode;
         this.saveChanges();
     }
 
     public void toggleLiteMode() {
         this.setLiteMode(!this.isLiteMode());
+    }
+
+    public void clearLiteMode() {
+        this.isLiteModeOverridden = false;
+        this.saveChanges();
     }
 
     private void updateLink(int idx, @Nullable ICraftingLink link) {
@@ -440,7 +457,9 @@ public class TileLevelMaintainer extends AENetworkTile
             }
         }
         data.setTag(NBT_REQUESTS, tagList);
-        data.setBoolean(NBT_LITE_MODE, isLiteMode());
+        if (this.isLiteModeOverridden) {
+            data.setBoolean(NBT_LITE_MODE, this.isLiteMode);
+        }
     }
 
     @TileEvent(TileEventType.WORLD_NBT_READ)
@@ -525,6 +544,7 @@ public class TileLevelMaintainer extends AENetworkTile
             }
         }
         if (data.hasKey(NBT_LITE_MODE)) {
+            this.isLiteModeOverridden = true;
             this.isLiteMode = data.getBoolean(NBT_LITE_MODE);
         }
     }

--- a/src/main/java/com/glodblock/github/common/tile/TileLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/common/tile/TileLevelMaintainer.java
@@ -389,6 +389,10 @@ public class TileLevelMaintainer extends AENetworkTile
         this.saveChanges();
     }
 
+    public void toggleLiteMode() {
+        this.setLiteMode(!this.isLiteMode());
+    }
+
     private void updateLink(int idx, @Nullable ICraftingLink link) {
         if (requests[idx] == null) return;
         requests[idx].link = link;

--- a/src/main/java/com/glodblock/github/network/CPacketLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/network/CPacketLevelMaintainer.java
@@ -16,11 +16,13 @@ public class CPacketLevelMaintainer implements IMessage {
         Batch,
         Enable,
         Disable,
+        LiteMode,
     }
 
     private Action action;
     private long size;
     private int slotIndex;
+    private boolean liteMode;
 
     @SuppressWarnings("unused")
     public CPacketLevelMaintainer() {}
@@ -29,12 +31,21 @@ public class CPacketLevelMaintainer implements IMessage {
         this.action = action;
         this.slotIndex = slotIndex;
         this.size = 0;
+        this.liteMode = false;
     }
 
     public CPacketLevelMaintainer(Action action, int slotIndex, long size) {
         this.action = action;
         this.slotIndex = slotIndex;
         this.size = size;
+        this.liteMode = false;
+    }
+
+    public CPacketLevelMaintainer(Action action, boolean liteMode) {
+        this.action = action;
+        this.slotIndex = -1;
+        this.size = 0;
+        this.liteMode = liteMode;
     }
 
     @Override
@@ -42,6 +53,7 @@ public class CPacketLevelMaintainer implements IMessage {
         this.action = Action.values()[buf.readInt()];
         this.slotIndex = buf.readInt();
         this.size = buf.readLong();
+        this.liteMode = buf.readBoolean();
     }
 
     @Override
@@ -49,6 +61,7 @@ public class CPacketLevelMaintainer implements IMessage {
         buf.writeInt(this.action.ordinal());
         buf.writeInt(this.slotIndex);
         buf.writeLong(this.size);
+        buf.writeBoolean(this.liteMode);
     }
 
     public static class Handler implements IMessageHandler<CPacketLevelMaintainer, IMessage> {
@@ -62,6 +75,7 @@ public class CPacketLevelMaintainer implements IMessage {
                     case Batch -> clm.getTile().updateBatchSize(message.slotIndex, message.size);
                     case Enable -> clm.getTile().updateStatus(message.slotIndex, false);
                     case Disable -> clm.getTile().updateStatus(message.slotIndex, true);
+                    case LiteMode -> clm.getTile().setLiteMode(message.liteMode);
                 }
                 clm.updateGui();
             }

--- a/src/main/java/com/glodblock/github/network/CPacketLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/network/CPacketLevelMaintainer.java
@@ -16,7 +16,8 @@ public class CPacketLevelMaintainer implements IMessage {
         Batch,
         Enable,
         Disable,
-        LiteMode,
+        ToggleLiteMode,
+        ClearLiteMode,
     }
 
     private Action action;
@@ -69,7 +70,8 @@ public class CPacketLevelMaintainer implements IMessage {
                     case Batch -> clm.getTile().updateBatchSize(message.slotIndex, message.size);
                     case Enable -> clm.getTile().updateStatus(message.slotIndex, false);
                     case Disable -> clm.getTile().updateStatus(message.slotIndex, true);
-                    case LiteMode -> clm.getTile().toggleLiteMode();
+                    case ToggleLiteMode -> clm.getTile().toggleLiteMode();
+                    case ClearLiteMode -> clm.getTile().clearLiteMode();
                 }
                 clm.updateGui();
             }

--- a/src/main/java/com/glodblock/github/network/CPacketLevelMaintainer.java
+++ b/src/main/java/com/glodblock/github/network/CPacketLevelMaintainer.java
@@ -22,30 +22,26 @@ public class CPacketLevelMaintainer implements IMessage {
     private Action action;
     private long size;
     private int slotIndex;
-    private boolean liteMode;
 
     @SuppressWarnings("unused")
     public CPacketLevelMaintainer() {}
+
+    public CPacketLevelMaintainer(Action action) {
+        this.action = action;
+        this.slotIndex = -1;
+        this.size = 0;
+    }
 
     public CPacketLevelMaintainer(Action action, int slotIndex) {
         this.action = action;
         this.slotIndex = slotIndex;
         this.size = 0;
-        this.liteMode = false;
     }
 
     public CPacketLevelMaintainer(Action action, int slotIndex, long size) {
         this.action = action;
         this.slotIndex = slotIndex;
         this.size = size;
-        this.liteMode = false;
-    }
-
-    public CPacketLevelMaintainer(Action action, boolean liteMode) {
-        this.action = action;
-        this.slotIndex = -1;
-        this.size = 0;
-        this.liteMode = liteMode;
     }
 
     @Override
@@ -53,7 +49,6 @@ public class CPacketLevelMaintainer implements IMessage {
         this.action = Action.values()[buf.readInt()];
         this.slotIndex = buf.readInt();
         this.size = buf.readLong();
-        this.liteMode = buf.readBoolean();
     }
 
     @Override
@@ -61,7 +56,6 @@ public class CPacketLevelMaintainer implements IMessage {
         buf.writeInt(this.action.ordinal());
         buf.writeInt(this.slotIndex);
         buf.writeLong(this.size);
-        buf.writeBoolean(this.liteMode);
     }
 
     public static class Handler implements IMessageHandler<CPacketLevelMaintainer, IMessage> {
@@ -75,7 +69,7 @@ public class CPacketLevelMaintainer implements IMessage {
                     case Batch -> clm.getTile().updateBatchSize(message.slotIndex, message.size);
                     case Enable -> clm.getTile().updateStatus(message.slotIndex, false);
                     case Disable -> clm.getTile().updateStatus(message.slotIndex, true);
-                    case LiteMode -> clm.getTile().setLiteMode(message.liteMode);
+                    case LiteMode -> clm.getTile().toggleLiteMode();
                 }
                 clm.updateGui();
             }

--- a/src/main/java/com/glodblock/github/network/SPacketLevelMaintainerGuiUpdate.java
+++ b/src/main/java/com/glodblock/github/network/SPacketLevelMaintainerGuiUpdate.java
@@ -18,13 +18,15 @@ public class SPacketLevelMaintainerGuiUpdate implements IMessage {
 
     private Info[] infoList;
     private boolean onlyState;
+    private boolean isLiteMode;
 
     @SuppressWarnings("unused")
     public SPacketLevelMaintainerGuiUpdate() {}
 
-    public SPacketLevelMaintainerGuiUpdate(RequestInfo[] requests, boolean onlyState) {
+    public SPacketLevelMaintainerGuiUpdate(RequestInfo[] requests, boolean onlyState, boolean isLiteMode) {
         this.infoList = new Info[REQ_COUNT];
         this.onlyState = onlyState;
+        this.isLiteMode = isLiteMode;
 
         for (int i = 0; i < REQ_COUNT; i++) {
             if (requests[i] == null) {
@@ -43,6 +45,7 @@ public class SPacketLevelMaintainerGuiUpdate implements IMessage {
     public void fromBytes(ByteBuf buf) {
         this.infoList = new Info[REQ_COUNT];
         this.onlyState = buf.readBoolean();
+        this.isLiteMode = buf.readBoolean();
 
         for (int i = 0; i < REQ_COUNT; i++) {
             if (buf.readBoolean()) {
@@ -64,6 +67,7 @@ public class SPacketLevelMaintainerGuiUpdate implements IMessage {
     @Override
     public void toBytes(ByteBuf buf) {
         buf.writeBoolean(this.onlyState);
+        buf.writeBoolean(this.isLiteMode);
         for (Info info : this.infoList) {
             buf.writeBoolean(info != null);
             if (info == null) continue;
@@ -114,6 +118,8 @@ public class SPacketLevelMaintainerGuiUpdate implements IMessage {
                         gui.updateComponent(i, info.quantity, info.batchSize, info.enable, info.state);
                     }
                 }
+
+                gui.updateComponent(message.isLiteMode);
             }
 
             return null;

--- a/src/main/java/com/glodblock/github/util/NameConst.java
+++ b/src/main/java/com/glodblock/github/util/NameConst.java
@@ -87,6 +87,7 @@ public class NameConst {
     public static final String TT_LEVEL_MAINTAINER_NOT_FOUND_DESC = TT_LEVEL_MAINTAINER + "not_found_desc";
     public static final String TT_LEVEL_MAINTAINER_CANT_CRAFT = TT_LEVEL_MAINTAINER + "cant_craft";
     public static final String TT_LEVEL_MAINTAINER_CANT_CRAFT_DESC = TT_LEVEL_MAINTAINER + "cant_craft_desc";
+    public static final String TT_LEVEL_MAINTAINER_LITE_CRAFT_DESC = TT_LEVEL_MAINTAINER + "lite_craft_desc";
     public static final String TT_CELL_PORTABLE = TT_KEY + "cell_portable";
     public static final String TT_WIRELESS = TT_KEY + "wireless.";
     public static final String TT_WIRELESS_INSTALLED = TT_WIRELESS + "installed";

--- a/src/main/resources/assets/ae2fc/lang/en_US.lang
+++ b/src/main/resources/assets/ae2fc/lang/en_US.lang
@@ -99,6 +99,7 @@ ae2fc.tooltip.level_maintainer.not_found=§4Not Found§r
 ae2fc.tooltip.level_maintainer.not_found_desc=The Requester is trying to schedule a crafting job but can't find a crafting pattern.
 ae2fc.tooltip.level_maintainer.cant_craft=§4Can't Craft§r
 ae2fc.tooltip.level_maintainer.cant_craft_desc=The Requester is trying to schedule a crafting job but the crafting manager cannot process the job. (not enough ingredients, CPU doesn't have enough memory, recursion).
+ae2fc.tooltip.level_maintainer.lite_craft_desc=Toggle lite crafting mode. Shift-click to clear override and restore network defaults.
 ae2fc.tooltip.level_maintainer.batch_size=§6Crafting Batch Size§r
 ae2fc.tooltip.level_maintainer.batch_size.hint=When craft requests are emitted, the Requester will use the batch size for the request. Using larger batches will increase the speed of stocking up items but will require more crafting storage.
 ae2fc.tooltip.level_maintainer.request_size=§6Amount to Maintain§r


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
level maintainer is laggy in late game. hope this would do some help to the spike lol
effect:
<img width="402" height="257" alt="Screenshot 2026-08-17 at 22 21 49" src="https://github.com/user-attachments/assets/b7c385ff-e1f6-4ecd-9be3-5c1c887c91e8" />

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
