### PR TITLE
Fix oreDict field in the magnet card filter

### DIFF
--- a/src/main/java/com/glodblock/github/client/gui/GuiMagnetFilter.java
+++ b/src/main/java/com/glodblock/github/client/gui/GuiMagnetFilter.java
@@ -144,6 +144,11 @@ public class GuiMagnetFilter extends GuiSub {
         this.components[1].setVar(this.cont.meta);
         this.components[2].setVar(this.cont.ore);
         this.components[3].setVar(this.cont.oreDict);
+        // the synced value arrives after initGui, so re-apply it while the field is not being edited
+        if (!oreDict.isFocused() && this.cont.oreDictFilter != null
+                && !this.cont.oreDictFilter.equals(oreDict.getText())) {
+            oreDict.setText(this.cont.oreDictFilter, true);
+        }
         for (Component c : components) {
             c.draw();
         }


### PR DESCRIPTION
## Summary
The magnet card filter stores its oreDict value in the terminal NBT. A Baubles slot is not resynced to the client when only the NBT changes, so the text field was filled from a stale stack and looked empty after reopening the GUI, until relog. The value already arrives through container sync, so it is now re-applied while the field is not being edited.

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
