### PR TITLE
Fix single-fluid cell contents tooltip

### DIFF
--- a/src/main/java/com/glodblock/github/common/item/FCBaseItemCell.java
+++ b/src/main/java/com/glodblock/github/common/item/FCBaseItemCell.java
@@ -2,7 +2,12 @@ package com.glodblock.github.common.item;
 
 import static appeng.util.item.AEFluidStackType.FLUID_STACK_TYPE;
 
+import java.util.List;
+
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumChatFormatting;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -10,8 +15,17 @@ import com.glodblock.github.common.storage.CellType;
 import com.glodblock.github.loader.ItemAndBlockHolder;
 import com.google.common.base.Optional;
 
+import appeng.api.AEApi;
+import appeng.api.storage.IMEInventoryHandler;
+import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEStackType;
+import appeng.core.localization.GuiText;
 import appeng.items.AEBaseCell;
+import appeng.me.storage.FluidCellInventoryHandler;
+import appeng.util.IterationCounter;
+import appeng.util.ReadableNumberConverter;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 
 public abstract class FCBaseItemCell extends AEBaseCell {
 
@@ -29,6 +43,38 @@ public abstract class FCBaseItemCell extends AEBaseCell {
     @Override
     public @NotNull IAEStackType<?> getStackType() {
         return FLUID_STACK_TYPE;
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void addCheckedInformation(final ItemStack stack, final EntityPlayer player, final List<String> lines,
+            final boolean displayMoreInfo) {
+        super.addCheckedInformation(stack, player, lines, displayMoreInfo);
+
+        final IMEInventoryHandler<?> inventory = AEApi.instance().registries().cell()
+                .getCellInventory(stack, null, getStackType());
+        if (!(inventory instanceof FluidCellInventoryHandler handler) || handler.getCellInv().getTotalItemTypes() != 1
+                || handler.getCellInv().getStoredItemTypes() == 0)
+            return;
+
+        final IAEFluidStack content = handler
+                .getAvailableItems(FLUID_STACK_TYPE.createPrimitiveList(), IterationCounter.fetchNewId())
+                .getFirstItem();
+        final String oldLine = GuiText.Contains.getLocal() + ": " + content.getDisplayName();
+        final int oldLineIndex = lines.lastIndexOf(oldLine);
+        if (oldLineIndex >= 0) {
+            if (!GuiScreen.isCtrlKeyDown()) {
+                lines.set(oldLineIndex, EnumChatFormatting.GRAY + GuiText.HoldCtrlForContents.getLocal());
+                return;
+            }
+            final String unit = FLUID_STACK_TYPE.getDisplayUnit();
+            lines.set(
+                    oldLineIndex,
+                    "  " + content.getDisplayName()
+                            + " x"
+                            + ReadableNumberConverter.INSTANCE.toWideReadableForm(content.getStackSize())
+                            + (unit.isEmpty() ? "" : " " + unit));
+        }
     }
 
     public FCBaseItemCell(Optional subName) {


### PR DESCRIPTION
## Summary

Fixes single-fluid cell tooltips so holding Ctrl displays the stored fluid and its amount in mB, matching multi-fluid cell behavior. Otherwise, the tooltip prompts the user to hold Ctrl.


## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
